### PR TITLE
fix(bot/auto-thread): Set first filename as thread title when message content is empty

### DIFF
--- a/apps/discord-bot/src/listeners/events/auto-thread.test.ts
+++ b/apps/discord-bot/src/listeners/events/auto-thread.test.ts
@@ -255,4 +255,49 @@ describe('Auto thread', () => {
 
 		expect(message.thread?.name).toEqual(`serverUsername - thread title`);
 	});
+	it('should use the filename when message content is empty', async () => {
+		// Make sure that the success case works, then we can test other cases
+		await succeedCreatingAThread();
+
+		const channel = mockTextChannel(client);
+
+		await createServer(toAOServer(channel.guild));
+		await createChannel({
+			...toAOChannel(channel),
+			flags: { autoThreadEnabled: true },
+		});
+
+		const author = mockGuildMember({
+			client,
+
+			data: {
+				user: {
+					username: 'serverUsername',
+					id: randomSnowflake().toString(),
+				},
+			},
+		});
+		const message = mockMessage({
+			client,
+			channel: channel,
+			author: author.user,
+			override: {
+				content: '',
+				attachments: [
+					{
+						filename: 'image.png',
+						id: randomSnowflake().toString(),
+						size: 12345,
+						url: 'https://media.discordapp.net/attachments/998841982212382731/1109114715348668456/image.png',
+						proxy_url:
+							'https://media.discordapp.net/attachments/998841982212382731/1109114715348668456/image.png',
+					},
+				],
+			},
+		});
+
+		await emitEvent(client, Events.MessageCreate, message);
+
+		expect(message.thread?.name).toEqual(`serverUsername - image.png`);
+	});
 });

--- a/apps/discord-bot/src/listeners/events/auto-thread.test.ts
+++ b/apps/discord-bot/src/listeners/events/auto-thread.test.ts
@@ -255,7 +255,7 @@ describe('Auto thread', () => {
 
 		expect(message.thread?.name).toEqual(`serverUsername - thread title`);
 	});
-	it('should use the filename when message content is empty', async () => {
+	it('should use the first filename when message content is empty and an attachment is present', async () => {
 		// Make sure that the success case works, then we can test other cases
 		await succeedCreatingAThread();
 

--- a/apps/discord-bot/src/listeners/events/auto-thread.ts
+++ b/apps/discord-bot/src/listeners/events/auto-thread.ts
@@ -17,11 +17,15 @@ async function autoThread(channelSettings: ChannelWithFlags, message: Message) {
 	if (!isHumanMessage(message)) return;
 	if (message.type !== MessageType.Default) return;
 	if (message.thread) return;
-	// Channel is text based, and message has been sent by a human
+	const authorName = message.member?.nickname ?? message.author.username;
 
-	let textTitle = `${message.member?.nickname ?? message.author.username} - ${
-		message.cleanContent
-	}`;
+	let textTitle = `${authorName} - ${message.cleanContent}`;
+	if (message.attachments.size > 0 && message.content.length === 0) {
+		textTitle = `${authorName} - ${
+			message.attachments.first()?.name ?? 'Attachment'
+		}`;
+	}
+
 	// Remove all markdown characters
 	textTitle = removeDiscordMarkdown(textTitle);
 	if (textTitle.length > 47) {

--- a/apps/discord-bot/src/listeners/events/auto-thread.ts
+++ b/apps/discord-bot/src/listeners/events/auto-thread.ts
@@ -18,16 +18,15 @@ async function autoThread(channelSettings: ChannelWithFlags, message: Message) {
 	if (message.type !== MessageType.Default) return;
 	if (message.thread) return;
 	const authorName = message.member?.nickname ?? message.author.username;
+	let threadTitleContent = message.cleanContent;
+	let textTitle = `${authorName} - ${threadTitleContent}`;
 
-	let textTitle = `${authorName} - ${message.cleanContent}`;
 	if (message.attachments.size > 0 && message.content.length === 0) {
-		textTitle = `${authorName} - ${
-			message.attachments.first()?.name ?? 'Attachment'
-		}`;
+		threadTitleContent = message.attachments.first()?.name ?? 'Attachment';
 	}
 
 	// Remove all markdown characters
-	textTitle = removeDiscordMarkdown(textTitle);
+	threadTitleContent = removeDiscordMarkdown(threadTitleContent);
 	if (textTitle.length > 47) {
 		textTitle = textTitle.slice(0, 47) + '...';
 	}

--- a/apps/discord-bot/src/listeners/events/auto-thread.ts
+++ b/apps/discord-bot/src/listeners/events/auto-thread.ts
@@ -19,7 +19,6 @@ async function autoThread(channelSettings: ChannelWithFlags, message: Message) {
 	if (message.thread) return;
 	const authorName = message.member?.nickname ?? message.author.username;
 	let threadTitleContent = message.cleanContent;
-	let textTitle = `${authorName} - ${threadTitleContent}`;
 
 	if (message.attachments.size > 0 && message.content.length === 0) {
 		threadTitleContent = message.attachments.first()?.name ?? 'Attachment';
@@ -27,6 +26,8 @@ async function autoThread(channelSettings: ChannelWithFlags, message: Message) {
 
 	// Remove all markdown characters
 	threadTitleContent = removeDiscordMarkdown(threadTitleContent);
+
+	let textTitle = `${authorName} - ${threadTitleContent}`;
 	if (textTitle.length > 47) {
 		textTitle = textTitle.slice(0, 47) + '...';
 	}


### PR DESCRIPTION
# Description

- Adds support for using attachments on the auto thread feature

Fixes #277 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- A test has been added to the auto-thread testing file

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works 
- [x] I have updated .env.example if I added a new environment variable
- [x] My PR title follows the [semantic commits](https://www.conventionalcommits.org/en/v1.0.0/) style 
