### PR TITLE
fix(ui/Message): stop images/attachments showing twice on messages with a solution

### DIFF
--- a/packages/ui/src/components/primitives/message/Message.tsx
+++ b/packages/ui/src/components/primitives/message/Message.tsx
@@ -80,7 +80,6 @@ export const MessageContentWithSolution = (
 	return (
 		<div>
 			<MessageContents {...props} />
-			<MessageAttachments {...props} />
 			<div className="mt-4 w-full rounded-lg  border-2 border-green-500 p-2 dark:border-green-400">
 				<span className="text-green-800 dark:text-green-400">Solution:</span>
 				<MessageBlurrer message={props.solution}>


### PR DESCRIPTION
# Description

Fixes images showing up twice - eg. 
<img width="943" alt="Screenshot 2024-01-26 at 22 22 51" src="https://github.com/AnswerOverflow/AnswerOverflow/assets/46378904/f10dbbce-a5d7-43d4-91dd-b1ee8aea3f6d">

Fixes N/A (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works 
- [x] I have updated .env.example if I added a new environment variable
- [x] My PR title follows the [semantic commits](https://www.conventionalcommits.org/en/v1.0.0/) style 
