### PR TITLE
fix embeds light theme

### DIFF
--- a/packages/ui/src/components/primitives/message/Embed.tsx
+++ b/packages/ui/src/components/primitives/message/Embed.tsx
@@ -42,7 +42,7 @@ export const Embed = (props: EmbedProps) => {
 
 	return (
 		<div
-			className="flex w-fit flex-col gap-1 rounded-standard bg-white/10 py-2 pl-4 pr-6"
+			className="flex w-fit flex-col gap-1 rounded-standard bg-black/5 dark:bg-white/10 py-2 pl-4 pr-6"
 			style={{
 				borderLeftColor: `#${numberToHex(props.embed.color)}` ?? '#FFFFFF',
 				borderLeftStyle: 'solid',


### PR DESCRIPTION
- fix(ui/Message): stop images/attachments showing twice on messages with a solution (#532)
- feat(ui, api): add support for non image message attachments, make s3 attachments work (#531)
- fix(web): don't mutate attachments
- fix(web): update message attachment props
- fix(web): update message attachment props
- feat(bot): archive solved threads after 5 minutes
- fix(web): NEXT_PUBLIC_NODE_ENV -> NODE_ENV
- fix(app): add dataunlocker to app dashboard
- feat(ui): Embed Support (#533)
- fix(ui/embeds): add black/5 background on light them
