### PR TITLE
feat(ui/embed): embed image support

### DIFF
--- a/apps/main-site/next.config.mjs
+++ b/apps/main-site/next.config.mjs
@@ -48,6 +48,7 @@ const config = {
 			'avatars.githubusercontent.com',
 			'media.discordapp.net',
 			'utfs.io',
+			'images-ext-2.discordapp.net',
 		],
 	},
 	// https://github.com/kkomelin/isomorphic-dompurify/issues/54

--- a/packages/ui/src/components/primitives/message/Embed.tsx
+++ b/packages/ui/src/components/primitives/message/Embed.tsx
@@ -39,7 +39,7 @@ const EmbedImage = (props: {
 		<div>
 			<Image
 				src={props.url}
-				className="w-auto h-96 rounded-standard object-contain"
+				className="h-96 w-auto rounded-standard object-contain"
 				width={props.width}
 				height={props.height}
 				// Would be nice to have proper alt text here in the future / AI generated alt text

--- a/packages/ui/src/components/primitives/message/Embed.tsx
+++ b/packages/ui/src/components/primitives/message/Embed.tsx
@@ -3,6 +3,7 @@ import { MessageProps } from './props';
 import { cn } from 'packages/ui/src/utils/utils';
 import { BlueLink } from '../ui/blue-link';
 import { parse } from './markdown/render';
+import Image from 'next/image';
 
 const EmbedText = async (props: {
 	text: string | undefined;
@@ -26,6 +27,28 @@ const EmbedField = (
 		<EmbedText text={props.value} />
 	</div>
 );
+
+const EmbedImage = (props: {
+	url?: string;
+	authorUsername: string;
+	width?: number;
+	height?: number;
+}) => {
+	if (!props.url) return null;
+	return (
+		<div>
+			<Image
+				src={props.url}
+				className="w-auto h-96 rounded-standard object-contain"
+				width={props.width}
+				height={props.height}
+				// Would be nice to have proper alt text here in the future / AI generated alt text
+				// (Like x's (twitter) alt text)
+				alt={`From ${props.authorUsername}`}
+			/>
+		</div>
+	);
+};
 
 export interface EmbedProps {
 	embed: NonNullable<MessageProps['message']['embeds']>[number];
@@ -71,6 +94,12 @@ export const Embed = (props: EmbedProps) => {
 			{embed.fields?.map((data, dataIteration) => (
 				<EmbedField {...data} key={`field-${dataIteration}`} />
 			))}
+			<EmbedImage
+				url={embed.image?.proxyUrl}
+				width={embed.image?.width}
+				height={embed.image?.height}
+				authorUsername={embed.author?.name ?? 'An unknown user'}
+			/>
 			<EmbedText className="text-sm" text={embed.footer?.text} />
 		</div>
 	);

--- a/packages/ui/src/components/primitives/message/Embed.tsx
+++ b/packages/ui/src/components/primitives/message/Embed.tsx
@@ -39,6 +39,7 @@ const EmbedImage = (props: {
 		<div>
 			<Image
 				src={props.url}
+				unoptimized
 				className="h-96 w-auto rounded-standard object-contain"
 				width={props.width}
 				height={props.height}


### PR DESCRIPTION
- feat(ui/Embed): support embed images, add images-ext-2.discordapp.net to next allowed image domains

# Description

Adds support for images in embeds

Fixes N/A (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works 
- [x] I have updated .env.example if I added a new environment variable
- [x] My PR title follows the [semantic commits](https://www.conventionalcommits.org/en/v1.0.0/) style 
