### PR TITLE
chore(web): increase max-w of `ChannelSelect`

### DIFF
--- a/packages/ui/src/pages/CommunityPage.tsx
+++ b/packages/ui/src/pages/CommunityPage.tsx
@@ -31,7 +31,7 @@ function ChannelSelectRow(props: ChannelSelectProps) {
 		return (
 			<LinkButton
 				variant={selected ? 'secondary' : 'outline'}
-				className="max-w-[200px] flex-shrink-0"
+				className="max-w-[300px] flex-shrink-0"
 				href={
 					props.tenant
 						? `/c/${channel.id}`


### PR DESCRIPTION
I suggest to increase the max-w of channel selects on larger screens as currently our channel names are truncated even though there is enough space horizontally

Before:
![CleanShot 2024-08-12 at 21 34 02](https://github.com/user-attachments/assets/c15c6238-6c88-4a3a-9cfb-173cb6549cfa)
