### PR TITLE
feat(main-site/ui): display op tag to messages which belong to op - fixes #617

### DIFF
--- a/packages/ui/src/message/Message.tsx
+++ b/packages/ui/src/message/Message.tsx
@@ -16,6 +16,8 @@ import { MessageAttachments } from './attachments';
 import { parse } from './markdown/render';
 import { MessageProps } from './props';
 
+export const MessageOPTag = () => <span className="text-muted-foreground border-2 border-muted-foreground px-1 rounded-md">OP</span>;
+
 export const MessageAuthorArea = (props: Pick<MessageProps, 'message'>) => {
 	const { message } = props;
 	return (

--- a/packages/ui/src/message/props.ts
+++ b/packages/ui/src/message/props.ts
@@ -12,4 +12,5 @@ export type MessageProps = {
 	 */
 	collapseContent?: boolean | number;
 	loadingStyle?: 'lazy' | 'eager';
+	op?: boolean;
 };

--- a/packages/ui/src/message/thin-message.tsx
+++ b/packages/ui/src/message/thin-message.tsx
@@ -2,11 +2,11 @@ import { DiscordAvatar } from '../discord-avatar';
 import { Link } from '../ui/link';
 import { TimeAgo } from '../ui/time-ago';
 import { cn } from '../utils/utils';
-import { MessageBlurrer, MessageBody } from './Message';
+import { MessageBlurrer, MessageBody, MessageOPTag } from './Message';
 import { MessageProps } from './props';
 
 export function ThinMessage(
-	props: Pick<MessageProps, 'message'> & {
+  props: Pick<MessageProps, ('message' | 'op')> & {
 		isSolution?: boolean;
 	},
 ) {
@@ -22,14 +22,17 @@ export function ThinMessage(
 					<div className="flex flex-row items-center gap-2 text-muted-foreground">
 						{message.public && !message.isAnonymous ? (
 							<Link
-								className="mr-1 hover:underline"
+								className="hover:underline"
 								href={`/u/${message.author.id}`}
 							>
 								{message.author.name}
 							</Link>
 						) : (
-							<span className="mr-1">{message.author.name}</span>
+							<span>{message.author.name}</span>
 						)}
+						{
+  						props.op && <MessageOPTag />
+						}
 						<span className="text-sm">•</span>
 						<TimeAgo snowflake={message.id} />
 					</div>

--- a/packages/ui/src/pages/MessageResultPage.tsx
+++ b/packages/ui/src/pages/MessageResultPage.tsx
@@ -156,7 +156,7 @@ export function MessageResultPage({
 
 			return (
 				<div className="p-2" key={message.id}>
-					<ThinMessage message={message} />
+					<ThinMessage message={message} op={message.author.id === firstMessage.author.id} />
 				</div>
 			);
 		})


### PR DESCRIPTION
Display "OP" next to messages which belong to original thread author

Fixes #617

<img width="785" alt="Screenshot 2024-10-31 at 17 23 20" src="https://github.com/user-attachments/assets/2421b275-d7e8-406c-938a-a10f1e090d6c">
