### PR TITLE
'noindex' on Userpages

### DIFF
--- a/apps/dashboard/src/app/dashboard/[serverId]/channels/page.tsx
+++ b/apps/dashboard/src/app/dashboard/[serverId]/channels/page.tsx
@@ -274,7 +274,7 @@ function ChooseSolvedTagCard(props: { selectedChannel: ChannelWithFlags }) {
 	return (
 		<SettingsCard
 			title="Choose Solved Tag"
-			description="Pick the tag that will be applied when a message is marked as a solution"
+			description="Pick the tag that will be applied when a message is marked by a user as the solution."
 			disabled={props.selectedChannel.type !== ChannelType.GuildForum}
 			disabledReason="This option is only available for forum channels."
 		>
@@ -386,8 +386,8 @@ export default function ChannelsPage() {
 					<ToggleChannelFlag
 						flagKey="indexingEnabled"
 						title="Indexing Enabled"
-						description="Enable indexing of a channel, indexing can take up to 24 hours to collect initial data depending on the channel volume."
-						label="Indexing Enabled"
+						description="Enable indexing of a channel. Indexing can take up to 24 hours to collect initial data depending on the channel volume."
+						label="Enabled"
 						selectedChannel={selectedChannel}
 					/>
 					<ToggleChannelFlag
@@ -395,7 +395,7 @@ export default function ChannelsPage() {
 						title="Forum Guidelines Consent Enabled"
 						disabled={selectedChannel?.type !== ChannelType.GuildForum}
 						disabledReason="This option is only available for forum channels."
-						description="Mark users making posts as consenting to display their messages. If enabling, put a disclaimer in the forum guidelines that their messages will be displayed publicly."
+						description="Marks all posts as public, and disables Username Anonymization for the selected channel. If enabled, add a public message disclaimer to your forum guidelines."
 						label="Enabled"
 						selectedChannel={selectedChannel}
 					/>
@@ -404,14 +404,14 @@ export default function ChannelsPage() {
 					<ToggleChannelFlag
 						flagKey="markSolutionEnabled"
 						title="Mark Solution Enabled"
-						description="Enable marking solutions to threads."
+						description="Highlights the marked solution under the user's question."
 						label="Enabled"
 						selectedChannel={selectedChannel}
 					/>
 					<ToggleChannelFlag
 						flagKey="sendMarkSolutionInstructionsInNewThreads"
 						title="Send Mark Solution Instructions in New Threads"
-						description="Send instructions to users on how to mark a solution in new threads."
+						description="Enables the bot to provide instructions to users on how to mark a solution in new threads."
 						label="Enabled"
 						disabled={!selectedChannel.flags.markSolutionEnabled}
 						disabledReason="This option is only available if mark solution is enabled."
@@ -423,7 +423,7 @@ export default function ChannelsPage() {
 					<ToggleChannelFlag
 						flagKey="autoThreadEnabled"
 						title="Auto Thread Enabled"
-						description="Automatically create threads for new messages."
+						description="Automatically create threads for new messages. Alternatively consider instead changing the channel type to 'forum' in Discord."
 						label="Enabled"
 						disabled={selectedChannel?.type !== ChannelType.GuildText}
 						disabledReason="This option is only available for text channels."

--- a/apps/dashboard/src/app/dashboard/[serverId]/settings/page.tsx
+++ b/apps/dashboard/src/app/dashboard/[serverId]/settings/page.tsx
@@ -119,9 +119,9 @@ export default function Settings() {
 					title="Anonymize Messages"
 					description={
 						<>
-							Replace user names with a random name. This is closer to
-							pseudonymous as users can still join the server and search for the
-							message content.
+							Replace Discord usernames with pseudonyms. Names will randomize
+							on page refresh. Can be disabled per-channel with "Forum
+							Guidelines Consent Enabled" option.
 						</>
 					}
 					label="Enabled"
@@ -132,7 +132,7 @@ export default function Settings() {
 					description={
 						<>
 							Add a consent prompt to the server rules to mark new users as
-							consenting to display their messages.
+							consenting to publicly display their messages.
 						</>
 					}
 					label="Enabled"

--- a/apps/main-site/public/robots.txt
+++ b/apps/main-site/public/robots.txt
@@ -39,4 +39,6 @@ Disallow: /api/
 Disallow: /dashboard/
 Disallow: /oemf7z50uh7w/
 Disallow: /ingest/
+Disallow: /u/
+Disallow: /*/u/
 Sitemap: https://www.answeroverflow.com/sitemap.xml

--- a/apps/main-site/src/app/(main-site)/(app)/u/[userId]/layout.tsx
+++ b/apps/main-site/src/app/(main-site)/(app)/u/[userId]/layout.tsx
@@ -14,6 +14,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 		alternates: {
 			canonical: `/u/${userInfo.id}`,
 		},
+		robots: {
+			index: false,
+		},
 		openGraph: {
 			title: `${userInfo.name} Posts - Answer Overflow`,
 			description: `See posts from ${userInfo.name} on Answer Overflow`,

--- a/apps/main-site/src/app/[domain]/(core)/u/[userId]/layout.tsx
+++ b/apps/main-site/src/app/[domain]/(core)/u/[userId]/layout.tsx
@@ -17,6 +17,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 		alternates: {
 			canonical: `${baseUrl}/u/${userInfo.id}`,
 		},
+		robots: {
+			index: false,
+		},
 		openGraph: {
 			title: `${userInfo.name} Posts - ${server.name}`,
 			description: `See posts from ${userInfo.name} in the ${server.name} Discord`,

--- a/apps/main-site/src/app/[domain]/robots.txt/route.ts
+++ b/apps/main-site/src/app/[domain]/robots.txt/route.ts
@@ -51,6 +51,8 @@ Disallow: /api/
 Disallow: /dashboard/
 Disallow: /oemf7z50uh7w/
 Disallow: /ingest/
+Disallow: /u/
+Disallow: /*/u/
 Sitemap: https://${domain}/sitemap.xml
 `,
 		{


### PR DESCRIPTION
We're blowing a lot of our budget and polutting our search results due to indexing userpages. 

Some users have chosen to accept the terms and have their usernames shown, making their profiles show up in Google search results. As they have thousands of messages, these are shown before other results. We would like to block all of these as we don't see the point of having individual userpages indexed at all.