### PR TITLE
Minor required fixes for local env start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Discord Bot
 # Get these values from here https://discord.com/developers/applications
 DISCORD_TOKEN = ""
-DISCORD_CLIENT_ID = ""
+NEXT_PUBLIC_DISCORD_CLIENT_ID = ""
 DISCORD_CLIENT_SECRET = ""
 
 DATABASE_URL = http://root:nonNullPassword@localhost:3900

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ DISCORD_TOKEN = ""
 NEXT_PUBLIC_DISCORD_CLIENT_ID = ""
 DISCORD_CLIENT_SECRET = ""
 
-DATABASE_URL="mysql://root:nonNullPassword@localhost:3306/answeroverflow"
+DATABASE_URL = http://root:nonNullPassword@localhost:3900'
 REDIS_URL=redis://:redis@localhost:6379
 
 ELASTICSEARCH_URL = http://localhost:9200

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ DISCORD_TOKEN = ""
 NEXT_PUBLIC_DISCORD_CLIENT_ID = ""
 DISCORD_CLIENT_SECRET = ""
 
-DATABASE_URL = http://root:nonNullPassword@localhost:3900'
+DATABASE_URL = http://root:nonNullPassword@localhost:3900
 REDIS_URL=redis://:redis@localhost:6379
 
 ELASTICSEARCH_URL = http://localhost:9200

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ DISCORD_TOKEN = ""
 NEXT_PUBLIC_DISCORD_CLIENT_ID = ""
 DISCORD_CLIENT_SECRET = ""
 
-DATABASE_URL = http://root:nonNullPassword@localhost:3900
+DATABASE_URL="mysql://root:nonNullPassword@localhost:3306/answeroverflow"
 REDIS_URL=redis://:redis@localhost:6379
 
 ELASTICSEARCH_URL = http://localhost:9200


### PR DESCRIPTION
### What this PR does
1. Changes the var `DISCORD_CLIENT_ID` to `NEXT_PUBLIC_DISCORD_ID` as it is required to run AO locally in a dev environment

2. Also updates `DATABASE_URL` to a proper format that expects a database called "answeroverflow"

## Why

### Starting with bun
Running `bun dev` gives the error:

```
No variable set for NEXT_PUBLIC_DISCORD_CLIENT_ID [REQUIRED]
```

because the var `DISCORD_CLIENT_ID` was changed to `NEXT_PUBLIC_DISCORD_ID`

### Database

The current database URL syntax isn't correct