### PR TITLE
Fix auth for remote dev access

### DIFF
--- a/apps/main-site/src/app/api/handlers/auth.ts
+++ b/apps/main-site/src/app/api/handlers/auth.ts
@@ -1,9 +1,21 @@
 import { nextJsHandler } from "@convex-dev/better-auth/nextjs";
 import type { Context } from "hono";
 
+function createRequestWithoutHost(request: Request): Request {
+	const headers = new Headers(request.headers);
+	headers.delete("host");
+	return new Request(request.url, {
+		method: request.method,
+		headers,
+		body: request.body,
+		// @ts-expect-error duplex is required for streaming bodies but not in all TS types
+		duplex: "half",
+	});
+}
+
 export async function handleAuth(c: Context) {
 	const method = c.req.method;
-	const request = c.req.raw;
+	const request = createRequestWithoutHost(c.req.raw);
 
 	const handler = nextJsHandler();
 

--- a/packages/database/convex/shared/betterAuth.ts
+++ b/packages/database/convex/shared/betterAuth.ts
@@ -17,6 +17,16 @@ const getTrustedOrigins = (siteUrl: string): string[] => {
 		}
 	}
 
+	const additionalOrigins = process.env.ADDITIONAL_TRUSTED_ORIGINS;
+	if (additionalOrigins) {
+		for (const origin of additionalOrigins.split(",")) {
+			const trimmed = origin.trim();
+			if (trimmed && !origins.includes(trimmed)) {
+				origins.push(trimmed);
+			}
+		}
+	}
+
 	return origins;
 };
 

--- a/packages/ui/src/components/convex-client-provider.tsx
+++ b/packages/ui/src/components/convex-client-provider.tsx
@@ -26,7 +26,6 @@ const queryClient = new QueryClient({
 convexQueryClient.connect(queryClient);
 
 export const authClient = createAuthClient({
-	baseURL: process.env.NEXT_PUBLIC_SITE_URL,
 	plugins: [anonymousClient(), convexClient()],
 });
 


### PR DESCRIPTION
## Summary
- Fix TLS certificate mismatch error when accessing dev server from non-localhost IPs (e.g., Tailscale)
- Add `ADDITIONAL_TRUSTED_ORIGINS` env var support for Better Auth to allow multiple trusted origins
- Make auth client use current page origin automatically instead of hardcoded `NEXT_PUBLIC_SITE_URL`

## Changes
1. **auth.ts**: Strip `Host` header before proxying to Convex to prevent TLS cert validation failures
2. **betterAuth.ts**: Support comma-separated `ADDITIONAL_TRUSTED_ORIGINS` env var 
3. **convex-client-provider.tsx**: Remove hardcoded `baseURL` so auth works from any origin

## Setup
Set `ADDITIONAL_TRUSTED_ORIGINS` in Convex env vars:
```bash
bunx convex env set ADDITIONAL_TRUSTED_ORIGINS "http://100.121.205.40:3000"
```