### PR TITLE
Fix OG image logo transparency

### DIFF
--- a/apps/main-site/src/app/og/post/route.tsx
+++ b/apps/main-site/src/app/og/post/route.tsx
@@ -314,7 +314,7 @@ export async function GET(req: Request) {
 			>
 				<AnswerOverflowLogo
 					style={{
-						fill: 'none',
+						fill: '#000',
 						stroke: '#000',
 						strokeWidth: 13,
 						strokeMiterlimit: 10,


### PR DESCRIPTION
## Summary
- Fix the AnswerOverflow logo in OG images appearing transparent/faded by changing `fill: 'none'` to `fill: '#000'` so the logo renders as a solid black color instead of just stroke outlines