### PR TITLE
perf: use indexed queries for message lookups

### DIFF
--- a/packages/database/convex/private/messages.ts
+++ b/packages/database/convex/private/messages.ts
@@ -369,8 +369,7 @@ export const getMessagePageData = privateQuery({
 		if (threadId) {
 			const threadStarterMessages = await ctx.db
 				.query("messages")
-				.withIndex("by_channelId", (q) => q.eq("channelId", parentId))
-				.filter((q) => q.eq(q.field("childThreadId"), threadId))
+				.withIndex("by_childThreadId", (q) => q.eq("childThreadId", threadId))
 				.collect();
 
 			const existingIds = new Set(allMessages.map((m) => m.id));

--- a/packages/database/convex/schema.ts
+++ b/packages/database/convex/schema.ts
@@ -235,6 +235,8 @@ export default defineSchema({
 		.index("by_channelId", ["channelId"])
 		.index("by_questionId", ["questionId"])
 		.index("by_parentChannelId", ["parentChannelId"])
+		.index("by_childThreadId", ["childThreadId"])
+		.index("by_channelId_and_id", ["channelId", "id"])
 		.searchIndex("search_content", {
 			searchField: "content",
 		}),


### PR DESCRIPTION
## Summary

- Add `by_childThreadId` and `by_channelId_and_id` indexes to messages table for efficient lookups
- Replace `.filter()` query with `.withIndex()` in `getMessagePageData` for thread starter messages
- Refactor `findMessagesByChannelId`, `getFirstMessageInChannel`, and `getFirstMessagesInChannels` to use index-based pagination instead of fetching all messages and sorting in memory

This eliminates O(n) table scans and in-memory sorting for message queries, improving performance especially for channels with many messages.