### PR TITLE
Optimize message pages to single network call

### DIFF
--- a/apps/main-site/src/app/[domain]/m/[messageId]/page.tsx
+++ b/apps/main-site/src/app/[domain]/m/[messageId]/page.tsx
@@ -2,6 +2,10 @@ import { Database } from "@packages/database/database";
 import { Effect } from "effect";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
+import {
+	fetchMessagePageData,
+	generateMessagePageMetadata,
+} from "../../../../components/message-page-loader";
 import { MessagePage } from "../../../../components/message-page";
 import { runtime } from "../../../../lib/runtime";
 
@@ -9,105 +13,38 @@ type Props = {
 	params: Promise<{ domain: string; messageId: string }>;
 };
 
-function getThreadIdOfMessage(message: {
-	channelId: bigint;
-	childThreadId?: bigint | null;
-	parentChannelId?: bigint | null;
-}): bigint | null {
-	if (message.childThreadId) {
-		return message.childThreadId;
-	}
-	if (message.parentChannelId) {
-		return message.channelId;
-	}
-	return null;
-}
-
 export async function generateMetadata(props: Props): Promise<Metadata> {
 	const params = await props.params;
-
-	const pageData = await Effect.gen(function* () {
-		const database = yield* Database;
-		const liveData = yield* database.private.messages.getMessagePageData({
-			messageId: BigInt(params.messageId),
-		});
-		return liveData;
-	}).pipe(runtime.runPromise);
-
-	if (!pageData) {
-		return {};
-	}
-
-	const firstMessage = pageData.messages.at(0);
-	const title =
-		pageData.thread?.name ??
-		firstMessage?.message.content?.slice(0, 100) ??
-		pageData.channel.name;
-	const description =
-		firstMessage?.message.content && firstMessage.message.content.length > 0
-			? firstMessage.message.content
-			: `Questions related to ${pageData.channel.name} in ${pageData.server.name}`;
-
-	return {
-		title: `${title} - ${pageData.server.name}`,
-		description,
-		openGraph: {
-			images: [`/og/post?id=${params.messageId}`],
-			title: `${title} - ${pageData.server.name}`,
-			description,
-		},
-		alternates: {
-			canonical: `/m/${pageData.thread?.id.toString() ?? params.messageId}`,
-		},
-	};
+	const pageData = await fetchMessagePageData(BigInt(params.messageId));
+	return generateMessagePageMetadata(pageData, params.messageId);
 }
 
 export default async function TenantMessagePage(props: Props) {
 	const params = await props.params;
 	const domain = decodeURIComponent(params.domain);
 
-	const tenantData = await Effect.gen(function* () {
+	const [tenantData, pageData] = await Effect.gen(function* () {
 		const database = yield* Database;
 		const tenant = yield* database.private.servers.getServerByDomain({
 			domain,
 		});
-		return tenant;
-	}).pipe(runtime.runPromise);
-
-	if (!tenantData?.server) {
-		return notFound();
-	}
-
-	const message = await Effect.gen(function* () {
-		const database = yield* Database;
-		return yield* database.private.messages.getMessageById({
-			id: BigInt(params.messageId),
-		});
-	}).pipe(runtime.runPromise);
-
-	if (!message) {
-		return notFound();
-	}
-
-	if (message.serverId !== tenantData.server.discordId) {
-		return notFound();
-	}
-
-	const threadId = getThreadIdOfMessage(message);
-	if (threadId && threadId.toString() !== params.messageId) {
-		redirect(`/m/${threadId.toString()}`);
-	}
-
-	const pageData = await Effect.gen(function* () {
-		const database = yield* Database;
-		const liveData = yield* database.private.messages.getMessagePageData({
+		const page = yield* database.private.messages.getMessagePageData({
 			messageId: BigInt(params.messageId),
 		});
-		return liveData;
+		return [tenant, page] as const;
 	}).pipe(runtime.runPromise);
 
-	if (!pageData) {
+	if (!tenantData?.server || !pageData) {
 		return notFound();
+	}
+
+	if (pageData.server.discordId !== tenantData.server.discordId) {
+		return notFound();
+	}
+
+	const canonicalId = pageData.canonicalId.toString();
+	if (canonicalId !== params.messageId) {
+		redirect(`/m/${canonicalId}`);
 	}
 
 	return <MessagePage data={pageData} />;

--- a/apps/main-site/src/app/m/[messageId]/page.tsx
+++ b/apps/main-site/src/app/m/[messageId]/page.tsx
@@ -1,97 +1,22 @@
-import { Database } from "@packages/database/database";
-import { Effect } from "effect";
 import type { Metadata } from "next";
-import { notFound, redirect } from "next/navigation";
-import { MessagePage } from "../../../components/message-page";
-import { runtime } from "../../../lib/runtime";
+import {
+	fetchMessagePageData,
+	generateMessagePageMetadata,
+	MessagePageLoader,
+} from "../../../components/message-page-loader";
 
 type Props = {
 	params: Promise<{ messageId: string }>;
 };
 
-function getThreadIdOfMessage(message: {
-	channelId: bigint;
-	childThreadId?: bigint | null;
-	parentChannelId?: bigint | null;
-}): bigint | null {
-	if (message.childThreadId) {
-		return message.childThreadId;
-	}
-	if (message.parentChannelId) {
-		return message.channelId;
-	}
-	return null;
-}
-
 export async function generateMetadata(props: Props): Promise<Metadata> {
 	const params = await props.params;
-
-	const pageData = await Effect.gen(function* () {
-		const database = yield* Database;
-		const liveData = yield* database.private.messages.getMessagePageData({
-			messageId: BigInt(params.messageId),
-		});
-		return liveData;
-	}).pipe(runtime.runPromise);
-
-	if (!pageData) {
-		return {};
-	}
-
-	const firstMessage = pageData.messages.at(0);
-	const title =
-		pageData.thread?.name ??
-		firstMessage?.message.content?.slice(0, 100) ??
-		pageData.channel.name;
-	const description =
-		firstMessage?.message.content && firstMessage.message.content.length > 0
-			? firstMessage.message.content
-			: `Questions related to ${pageData.channel.name} in ${pageData.server.name}`;
-
-	return {
-		title: `${title} - ${pageData.server.name}`,
-		description,
-		openGraph: {
-			images: [`/og/post?id=${params.messageId}`],
-			title: `${title} - ${pageData.server.name}`,
-			description,
-		},
-		alternates: {
-			canonical: `/m/${pageData.thread?.id.toString() ?? params.messageId}`,
-		},
-	};
+	const pageData = await fetchMessagePageData(BigInt(params.messageId));
+	return generateMessagePageMetadata(pageData, params.messageId);
 }
 
 export default async function Page(props: Props) {
 	const params = await props.params;
-
-	const message = await Effect.gen(function* () {
-		const database = yield* Database;
-		return yield* database.private.messages.getMessageById({
-			id: BigInt(params.messageId),
-		});
-	}).pipe(runtime.runPromise);
-
-	if (!message) {
-		return notFound();
-	}
-
-	const threadId = getThreadIdOfMessage(message);
-	if (threadId && threadId.toString() !== params.messageId) {
-		redirect(`/m/${threadId.toString()}`);
-	}
-
-	const pageData = await Effect.gen(function* () {
-		const database = yield* Database;
-		const liveData = yield* database.private.messages.getMessagePageData({
-			messageId: BigInt(params.messageId),
-		});
-		return liveData;
-	}).pipe(runtime.runPromise);
-
-	if (!pageData) {
-		return notFound();
-	}
-
-	return <MessagePage data={pageData} />;
+	const pageData = await fetchMessagePageData(BigInt(params.messageId));
+	return <MessagePageLoader pageData={pageData} messageId={params.messageId} />;
 }

--- a/apps/main-site/src/components/message-page-loader.tsx
+++ b/apps/main-site/src/components/message-page-loader.tsx
@@ -1,0 +1,73 @@
+import { Database } from "@packages/database/database";
+import type { api } from "@packages/database/convex/_generated/api";
+import { Effect } from "effect";
+import type { FunctionReturnType } from "convex/server";
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { runtime } from "../lib/runtime";
+import { MessagePage } from "./message-page";
+
+export type MessagePageData = NonNullable<
+	FunctionReturnType<typeof api.private.messages.getMessagePageData>
+>;
+
+export async function fetchMessagePageData(
+	messageId: bigint,
+): Promise<MessagePageData | null> {
+	return Effect.gen(function* () {
+		const database = yield* Database;
+		return yield* database.private.messages.getMessagePageData({
+			messageId,
+		});
+	}).pipe(runtime.runPromise);
+}
+
+export function generateMessagePageMetadata(
+	pageData: MessagePageData | null,
+	messageId: string,
+): Metadata {
+	if (!pageData) {
+		return {};
+	}
+
+	const firstMessage = pageData.messages.at(0);
+	const title =
+		pageData.thread?.name ??
+		firstMessage?.message.content?.slice(0, 100) ??
+		pageData.channel.name;
+	const description =
+		firstMessage?.message.content && firstMessage.message.content.length > 0
+			? firstMessage.message.content
+			: `Questions related to ${pageData.channel.name} in ${pageData.server.name}`;
+
+	return {
+		title: `${title} - ${pageData.server.name}`,
+		description,
+		openGraph: {
+			images: [`/og/post?id=${messageId}`],
+			title: `${title} - ${pageData.server.name}`,
+			description,
+		},
+		alternates: {
+			canonical: `/m/${pageData.canonicalId.toString()}`,
+		},
+	};
+}
+
+export function MessagePageLoader(props: {
+	pageData: MessagePageData | null;
+	messageId: string;
+}) {
+	const { pageData, messageId } = props;
+
+	if (!pageData) {
+		return notFound();
+	}
+
+	const canonicalId = pageData.canonicalId.toString();
+	if (canonicalId !== messageId) {
+		redirect(`/m/${canonicalId}`);
+	}
+
+	return <MessagePage data={pageData} />;
+}

--- a/packages/database/convex/private/messages.ts
+++ b/packages/database/convex/private/messages.ts
@@ -410,6 +410,7 @@ export const getMessagePageData = privateQuery({
 		);
 
 		return {
+			canonicalId: threadId ?? targetMessage.id,
 			messages: enrichedMessages,
 			server: {
 				_id: server._id,


### PR DESCRIPTION
## Summary
- Eliminate redundant network call on message pages by returning `canonicalId` from `getMessagePageData`, reducing page loads from 2 DB calls to 1
- Extract shared `message-page-loader.tsx` with reusable `fetchMessagePageData`, `generateMessagePageMetadata`, and `MessagePageLoader` components to reduce code duplication across message page routes