### PR TITLE
Fix accessibility, use convex-helpers relationships, migrate to nuqs, improve Effect patterns

### DIFF
--- a/apps/main-site/src/app/dashboard/[serverId]/settings/components.tsx
+++ b/apps/main-site/src/app/dashboard/[serverId]/settings/components.tsx
@@ -15,7 +15,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import dayjs from "dayjs";
 import { CheckCircle, CreditCard } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { useAuthenticatedQuery } from "../../../../lib/use-authenticated-query";
 
 type Plan =
@@ -143,14 +143,13 @@ function ManageBillingButton(props: { serverId: bigint }) {
 }
 
 function useSyncAfterCheckout(serverId: string) {
-	const searchParams = useSearchParams();
-	const router = useRouter();
+	const [success, setSuccess] = useQueryState("success");
 	const queryClient = useQueryClient();
 	const syncAfterCheckout = useAction(
 		api.authenticated.stripe.syncAfterCheckout,
 	);
 
-	const hasSuccess = searchParams.get("success") === "true";
+	const hasSuccess = success === "true";
 
 	const { isLoading: isSyncing, isSuccess: syncSuccess } = useQuery({
 		queryKey: ["sync-after-checkout", serverId],
@@ -159,9 +158,7 @@ function useSyncAfterCheckout(serverId: string) {
 			queryClient.invalidateQueries({
 				queryKey: ["subscription-info", serverId],
 			});
-			const url = new URL(window.location.href);
-			url.searchParams.delete("success");
-			router.replace(url.pathname + url.search);
+			await setSuccess(null);
 			return result;
 		},
 		enabled: hasSuccess,

--- a/apps/main-site/src/app/dashboard/onboarding/page.tsx
+++ b/apps/main-site/src/app/dashboard/onboarding/page.tsx
@@ -16,7 +16,8 @@ import { Skeleton } from "@packages/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { CheckCircle2 } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { useEffect, useState } from "react";
 import { authClient } from "../../../lib/auth-client";
 
@@ -24,8 +25,7 @@ type OnboardingStep = "auth" | "install" | "complete";
 
 export default function OnboardingPage() {
 	const router = useRouter();
-	const searchParams = useSearchParams();
-	const serverId = searchParams.get("serverId");
+	const [serverId] = useQueryState("serverId");
 	const { data: session, isPending: isSessionPending } = useSession({
 		allowAnonymous: false,
 	});

--- a/apps/main-site/src/app/dev-auth/receive/page.tsx
+++ b/apps/main-site/src/app/dev-auth/receive/page.tsx
@@ -9,7 +9,7 @@ import {
 	CardTitle,
 } from "@packages/ui/components/card";
 import { Link } from "@packages/ui/components/link";
-import { useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useState } from "react";
 
 const MAIN_SITE_ORIGIN = "https://new.answeroverflow.com";
@@ -24,8 +24,8 @@ function generateState(): string {
 }
 
 export default function DevAuthReceivePage() {
-	const searchParams = useSearchParams();
-	const redirect = searchParams.get("redirect") ?? "/";
+	const [redirectParam] = useQueryState("redirect");
+	const redirect = redirectParam ?? "/";
 	const [status, setStatus] = useState<
 		"idle" | "pending" | "success" | "error"
 	>("idle");

--- a/packages/database/convex/authenticated/dashboard_queries.ts
+++ b/packages/database/convex/authenticated/dashboard_queries.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { asyncMap } from "convex-helpers";
-import { getOneFrom } from "convex-helpers/server/relationships";
+import { getManyFrom, getOneFrom } from "convex-helpers/server/relationships";
 import { Array as Arr, Predicate } from "effect";
 import { authenticatedQuery } from "../client";
 import { guildManagerQuery } from "../client/guildManager";
@@ -27,10 +27,12 @@ export const getDashboardData = guildManagerQuery({
 			args.serverId,
 		);
 
-		const allChannels = await ctx.db
-			.query("channels")
-			.withIndex("by_serverId", (q) => q.eq("serverId", args.serverId))
-			.collect();
+		const allChannels = await getManyFrom(
+			ctx.db,
+			"channels",
+			"by_serverId",
+			args.serverId,
+		);
 
 		const channels = allChannels.filter(
 			(channel) => !isThreadType(channel.type),
@@ -97,10 +99,12 @@ export const getUserServersForDropdown = authenticatedQuery({
 	handler: async (ctx, args) => {
 		const { discordAccountId } = args;
 
-		const userServerSettings = await ctx.db
-			.query("userServerSettings")
-			.withIndex("by_userId", (q) => q.eq("userId", discordAccountId))
-			.collect();
+		const userServerSettings = await getManyFrom(
+			ctx.db,
+			"userServerSettings",
+			"by_userId",
+			discordAccountId,
+		);
 
 		const manageableSettings = userServerSettings.filter((setting) => {
 			const permissions = setting.permissions;

--- a/packages/database/convex/shared/messages.ts
+++ b/packages/database/convex/shared/messages.ts
@@ -212,10 +212,13 @@ export async function upsertMessageInternalLogic(
 	}
 
 	if (attachments !== undefined) {
-		const existingAttachments = await ctx.db
-			.query("attachments")
-			.withIndex("by_messageId", (q) => q.eq("messageId", messageData.id))
-			.collect();
+		const existingAttachments = await getManyFrom(
+			ctx.db,
+			"attachments",
+			"by_messageId",
+			messageData.id,
+			"messageId",
+		);
 
 		for (const attachment of existingAttachments) {
 			await ctx.db.delete(attachment._id);
@@ -229,10 +232,13 @@ export async function upsertMessageInternalLogic(
 	}
 
 	if (reactions !== undefined) {
-		const existingReactions = await ctx.db
-			.query("reactions")
-			.withIndex("by_messageId", (q) => q.eq("messageId", messageData.id))
-			.collect();
+		const existingReactions = await getManyFrom(
+			ctx.db,
+			"reactions",
+			"by_messageId",
+			messageData.id,
+			"messageId",
+		);
 
 		for (const reaction of existingReactions) {
 			await ctx.db.delete(reaction._id);

--- a/packages/database/convex/shared/users.ts
+++ b/packages/database/convex/shared/users.ts
@@ -1,4 +1,4 @@
-import { getOneFrom } from "convex-helpers/server/relationships";
+import { getManyFrom, getOneFrom } from "convex-helpers/server/relationships";
 import type { MutationCtx, QueryCtx } from "../client";
 
 export async function getDiscordAccountById(
@@ -78,10 +78,12 @@ export async function deleteUserServerSettingsByUserIdLogic(
 	ctx: MutationCtx,
 	userId: bigint,
 ): Promise<void> {
-	const settings = await ctx.db
-		.query("userServerSettings")
-		.withIndex("by_userId", (q) => q.eq("userId", userId))
-		.collect();
+	const settings = await getManyFrom(
+		ctx.db,
+		"userServerSettings",
+		"by_userId",
+		userId,
+	);
 
 	for (const setting of settings) {
 		await ctx.db.delete(setting._id);

--- a/packages/ui/src/components/discord-message/attachments.tsx
+++ b/packages/ui/src/components/discord-message/attachments.tsx
@@ -62,11 +62,11 @@ function FileShowcase({ attachment }: { attachment: Attachment }) {
 			<div className="group-hover:fade-in-0 group-hover:zoom-in-95 absolute top-0 right-0 translate-x-[50%] translate-y-[-50%] opacity-0 transition-opacity duration-300 group-hover:animate-in group-hover:opacity-100">
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<a href={attachmentUrl} target="_blank" rel="noreferrer">
-							<Button size="icon" variant="outline">
+						<Button size="icon" variant="outline" asChild>
+							<a href={attachmentUrl} target="_blank" rel="noreferrer">
 								<ArrowUpRight className="size-6" />
-							</Button>
-						</a>
+							</a>
+						</Button>
 					</TooltipTrigger>
 					<TooltipContent>
 						<p>Open attachment</p>

--- a/packages/ui/src/components/discord-message/spoiler.tsx
+++ b/packages/ui/src/components/discord-message/spoiler.tsx
@@ -6,8 +6,11 @@ import { cn } from "../../lib/utils";
 export function Spoiler({ children }: { children: React.ReactNode }) {
 	const [isOpen, setIsOpen] = useState(false);
 
+	const reveal = () => setIsOpen(true);
+
 	return (
-		<span
+		<button
+			type="button"
 			className={cn(
 				"not-prose inline-block w-fit select-none rounded border border-neutral-300 px-1 leading-[22px] transition-all",
 				{
@@ -17,9 +20,17 @@ export function Spoiler({ children }: { children: React.ReactNode }) {
 				},
 			)}
 			draggable="false"
-			onClick={() => setIsOpen(true)}
+			onClick={reveal}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					reveal();
+				}
+			}}
+			aria-pressed={isOpen}
+			aria-label={isOpen ? "Spoiler revealed" : "Click to reveal spoiler"}
 		>
 			{children}
-		</span>
+		</button>
 	);
 }

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -276,14 +276,14 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
 
 	return (
 		<button
+			type="button"
 			data-sidebar="rail"
 			data-slot="sidebar-rail"
 			aria-label="Toggle Sidebar"
-			tabIndex={-1}
 			onClick={toggleSidebar}
 			title="Toggle Sidebar"
 			className={cn(
-				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:outline-none group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
 				"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
 				"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
 				"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",


### PR DESCRIPTION
## Summary

- **Accessibility**: Fixed interactive elements - converted `<span onClick>` to proper `<button>` with keyboard support in spoiler component, fixed nested interactive elements in attachments, restored keyboard focus on sidebar rail
- **Convex relationships**: Replaced manual `.withIndex().collect()` patterns with `getManyFrom` helper from convex-helpers in dashboard queries, messages, and users modules
- **nuqs migration**: Replaced `useSearchParams` with type-safe `useQueryState` from nuqs for URL state management in onboarding, settings, and dev-auth pages
- **Effect patterns**: Replaced `Effect.promise` with `discord.callClient` pattern in mark-solution command, replaced try/catch loops with `Effect.forEach` + `Effect.tryPromise` in indexing service