### PR TITLE
Refactor indexing service with Effect-idiomatic patterns

### DIFF
--- a/apps/discord-bot/src/services/indexing.ts
+++ b/apps/discord-bot/src/services/indexing.ts
@@ -8,18 +8,19 @@ import type {
 	NewsChannel,
 	TextChannel,
 } from "discord.js";
-import { ChannelType } from "discord.js";
+import { ChannelType, PermissionFlagsBits } from "discord.js";
 import {
 	Array as Arr,
 	BigInt as BigIntEffect,
+	Cause,
 	Clock,
-	Console,
+	Data,
 	Duration,
 	Effect,
-	HashMap,
 	Layer,
+	Option,
 	Order,
-	Predicate,
+	pipe,
 	Schedule,
 } from "effect";
 import { Discord } from "../core/discord-service";
@@ -36,161 +37,305 @@ import {
 } from "../utils/conversions";
 import { isHumanMessage } from "../utils/message-utils";
 
-const INDEXING_CONFIG = {
+class IndexingError extends Data.TaggedError("IndexingError")<{
+	readonly operation: string;
+	readonly context: string;
+	readonly cause?: unknown;
+}> {}
+
+const IndexingConfig = {
 	scheduleInterval: Duration.hours(6),
 	maxMessagesPerChannel: 10000,
 	messagesPerPage: 100,
 	channelProcessDelay: Duration.millis(100),
 	guildProcessDelay: Duration.millis(500),
+	threadConcurrency: 3,
+	channelConcurrency: 2,
+	messageConcurrency: 5,
+	authorConcurrency: 10,
 } as const;
 
-function fetchChannelMessages(
+const bySnowflakeAsc = Order.mapInput(BigIntEffect.Order, (msg: Message) =>
+	BigInt(msg.id),
+);
+
+const byThreadSnowflakeDesc = Order.reverse(
+	Order.mapInput(BigIntEffect.Order, (thread: AnyThreadChannel) =>
+		BigInt(thread.id),
+	),
+);
+
+const isIndexableThread = (
+	thread: AnyThreadChannel | null | undefined,
+): thread is AnyThreadChannel =>
+	thread !== null &&
+	thread !== undefined &&
+	(thread.type === ChannelType.PublicThread ||
+		thread.type === ChannelType.AnnouncementThread);
+
+const isIndexableChannel = (channel: Channel) =>
+	channel.type === ChannelType.GuildText ||
+	channel.type === ChannelType.GuildAnnouncement ||
+	channel.type === ChannelType.GuildForum;
+
+const ensureInviteCode = (
+	channel: TextChannel | NewsChannel | ForumChannel,
+	currentInviteCode: string | undefined,
+) =>
+	Effect.gen(function* () {
+		if (currentInviteCode) {
+			return Option.some(currentInviteCode);
+		}
+
+		const canMakeInvites = channel
+			.permissionsFor(channel.client.user)
+			?.has(PermissionFlagsBits.CreateInstantInvite);
+		const vanityURLCode = channel.guild.vanityURLCode;
+
+		if (!canMakeInvites && !vanityURLCode) {
+			yield* Effect.logDebug(
+				`Cannot create invite for channel ${channel.name} - no permissions and no vanity URL`,
+			);
+			return Option.none();
+		}
+
+		const database = yield* Database;
+
+		const inviteCode = yield* pipe(
+			Effect.tryPromise({
+				try: async () => {
+					if (canMakeInvites) {
+						const invite = await channel.createInvite({
+							maxAge: 0,
+							maxUses: 0,
+							reason: "Channel indexing enabled invite",
+							unique: false,
+							temporary: false,
+						});
+						return invite.code;
+					}
+					return vanityURLCode ?? undefined;
+				},
+				catch: (error) =>
+					new IndexingError({
+						operation: "createInvite",
+						context: `channel ${channel.name}`,
+						cause: error,
+					}),
+			}),
+			Effect.tapError((error) =>
+				Effect.logWarning(`Failed to create invite: ${error.context}`),
+			),
+			Effect.orElseSucceed(() => vanityURLCode ?? undefined),
+		);
+
+		if (inviteCode) {
+			yield* database.private.channels.updateChannelSettings({
+				channelId: BigInt(channel.id),
+				settings: { inviteCode },
+			});
+			yield* Effect.logDebug(
+				`Created invite code ${inviteCode} for channel ${channel.name}`,
+			);
+		}
+
+		return Option.fromNullable(inviteCode);
+	});
+
+type FetchState = {
+	messages: Message[];
+	lastId: string;
+	hasMore: boolean;
+};
+
+const fetchChannelMessages = (
 	channelId: string,
 	channelName: string,
 	startFromId?: string,
-) {
-	return Effect.gen(function* () {
+) =>
+	Effect.gen(function* () {
 		const discord = yield* Discord;
-		const messages: Message[] = [];
-		let lastMessageId = startFromId ?? "0";
-		let hasMore = true;
-
-		if (startFromId) {
-			yield* Effect.logDebug(
-				`Fetching messages for ${channelName} (${channelId}) starting after message ${startFromId}`,
-			);
-		} else {
-			yield* Effect.logDebug(
-				`Fetching messages for ${channelName} (${channelId}) from beginning`,
-			);
-		}
-
-		while (hasMore && messages.length < INDEXING_CONFIG.maxMessagesPerChannel) {
-			const fetchAfter = lastMessageId === "0" ? undefined : lastMessageId;
-			const fetchedMessages = yield* discord.fetchChannelMessages(channelId, {
-				limit: INDEXING_CONFIG.messagesPerPage,
-				after: fetchAfter,
-			});
-
-			if (fetchedMessages.size === 0) {
-				hasMore = false;
-				break;
-			}
-
-			const sortedMessages = Arr.sort(
-				Arr.fromIterable(fetchedMessages.values()),
-				Order.mapInput(BigIntEffect.Order, (msg: Message) => BigInt(msg.id)),
-			);
-
-			messages.push(...sortedMessages);
-
-			const lastMsg = sortedMessages[sortedMessages.length - 1];
-			if (lastMsg && lastMsg.id !== lastMessageId) {
-				lastMessageId = lastMsg.id;
-			} else {
-				hasMore = false;
-			}
-
-			if (fetchedMessages.size < INDEXING_CONFIG.messagesPerPage) {
-				hasMore = false;
-			}
-		}
 
 		yield* Effect.logDebug(
-			`Fetched ${messages.length} messages from channel ${channelName} (${channelId})`,
+			startFromId
+				? `Fetching messages for ${channelName} (${channelId}) starting after ${startFromId}`
+				: `Fetching messages for ${channelName} (${channelId}) from beginning`,
 		);
-		return messages;
-	});
-}
 
-function fetchForumThreads(forumChannelId: string, forumChannelName: string) {
-	return Effect.gen(function* () {
+		const initialState: FetchState = {
+			messages: [],
+			lastId: startFromId ?? "0",
+			hasMore: true,
+		};
+
+		const finalState = yield* Effect.iterate(initialState, {
+			while: (state) =>
+				state.hasMore &&
+				state.messages.length < IndexingConfig.maxMessagesPerChannel,
+			body: (state) =>
+				Effect.gen(function* () {
+					const fetchAfter = state.lastId === "0" ? undefined : state.lastId;
+
+					const fetched = yield* discord.fetchChannelMessages(channelId, {
+						limit: IndexingConfig.messagesPerPage,
+						after: fetchAfter,
+					});
+
+					if (fetched.size === 0) {
+						return { ...state, hasMore: false };
+					}
+
+					const sorted = Arr.sort(
+						Arr.fromIterable(fetched.values()),
+						bySnowflakeAsc,
+					);
+
+					const lastMsg = Arr.last(sorted);
+					const newLastId = Option.isSome(lastMsg)
+						? lastMsg.value.id
+						: state.lastId;
+					const shouldContinue =
+						fetched.size >= IndexingConfig.messagesPerPage &&
+						newLastId !== state.lastId;
+
+					return {
+						messages: [...state.messages, ...sorted],
+						lastId: newLastId,
+						hasMore: shouldContinue,
+					};
+				}),
+		});
+
+		yield* Effect.logDebug(
+			`Fetched ${finalState.messages.length} messages from ${channelName}`,
+		);
+
+		return finalState.messages;
+	});
+
+type ArchivedThreadState = {
+	threads: AnyThreadChannel[];
+	beforeId: string | undefined;
+	hasMore: boolean;
+};
+
+const fetchForumThreads = (forumChannelId: string, forumChannelName: string) =>
+	Effect.gen(function* () {
 		const discord = yield* Discord;
-		const threads: AnyThreadChannel[] = [];
 
 		const activeThreads = yield* discord.fetchActiveThreads(forumChannelId);
+		const active = Arr.fromIterable(activeThreads.threads.values());
 
-		threads.push(...Arr.fromIterable(activeThreads.threads.values()));
+		const initialState: ArchivedThreadState = {
+			threads: [],
+			beforeId: undefined,
+			hasMore: true,
+		};
 
-		let hasMoreArchived = true;
-		let beforeId: string | undefined;
+		const archivedState = yield* Effect.iterate(initialState, {
+			while: (state) => state.hasMore,
+			body: (state) =>
+				Effect.gen(function* () {
+					const fetched = yield* discord.fetchArchivedThreads(forumChannelId, {
+						before: state.beforeId,
+					});
 
-		while (hasMoreArchived) {
-			const archivedThreads = yield* discord.fetchArchivedThreads(
-				forumChannelId,
-				{ before: beforeId },
-			);
+					const threads = Arr.fromIterable(fetched.threads.values());
+					const lastThread = fetched.threads.last();
 
-			threads.push(...Arr.fromIterable(archivedThreads.threads.values()));
+					return {
+						threads: [...state.threads, ...threads],
+						beforeId: lastThread?.id,
+						hasMore: fetched.hasMore && threads.length > 0,
+					};
+				}),
+		});
 
-			if (!archivedThreads.hasMore || archivedThreads.threads.size === 0) {
-				hasMoreArchived = false;
-			} else {
-				const lastThread = archivedThreads.threads.last();
-				beforeId = lastThread?.id;
-			}
-		}
+		const archived = archivedState.threads;
+		const allThreads = [...active, ...archived];
 
 		yield* Effect.logDebug(
-			`Found ${threads.length} threads in forum ${forumChannelName} (${forumChannelId})`,
+			`Found ${allThreads.length} threads in forum ${forumChannelName}`,
 		);
-		return threads;
-	});
-}
 
-function storeMessages(
+		return allThreads;
+	});
+
+const convertAndFilterMessages = (
 	messages: Message[],
 	discordServerId: string,
-	channelId: string,
-) {
-	return Effect.gen(function* () {
-		const database = yield* Database;
+) =>
+	Effect.gen(function* () {
+		const humanMessages = Arr.filter(messages, isHumanMessage);
 
-		if (messages.length === 0) {
-			yield* Effect.logDebug(`No messages to store for channel ${channelId}`);
-			return;
-		}
-
-		const humanMessages = Arr.filter(messages, (msg) => isHumanMessage(msg));
-
-		yield* Effect.logDebug(
-			`Storing ${humanMessages.length} human messages (filtered from ${messages.length} total)`,
-		);
-
-		const aoMessages = yield* Effect.forEach(
+		const converted = yield* Effect.forEach(
 			humanMessages,
 			(msg) =>
-				Effect.tryPromise(() => toAOMessage(msg, discordServerId)).pipe(
-					Effect.catchAll((error) =>
-						Effect.gen(function* () {
-							yield* Console.warn(
-								`Failed to convert message ${msg.id}:`,
-								error,
-							);
-							return null;
-						}),
+				pipe(
+					Effect.tryPromise(() => toAOMessage(msg, discordServerId)),
+					Effect.tapError((error) =>
+						Effect.logWarning(`Failed to convert message ${msg.id}: ${error}`),
 					),
+					Effect.option,
 				),
 			{ concurrency: "unbounded" },
-		).pipe(Effect.map(Arr.filter(Predicate.isNotNull)));
+		);
 
-		const uniqueAuthors = HashMap.fromIterable(
+		return {
+			humanMessages,
+			aoMessages: Arr.filterMap(converted, (opt) => opt),
+		};
+	});
+
+const upsertAuthors = (humanMessages: Message[]) =>
+	Effect.gen(function* () {
+		const database = yield* Database;
+
+		const uniqueAuthors = pipe(
+			humanMessages,
 			Arr.map(
-				humanMessages,
 				(msg) => [msg.author.id, toAODiscordAccount(msg.author)] as const,
 			),
+			(entries) => new Map(entries),
+			(map) => Arr.fromIterable(map.values()),
 		);
 
 		yield* Effect.forEach(
-			Arr.fromIterable(HashMap.values(uniqueAuthors)),
+			uniqueAuthors,
 			(author) =>
 				database.private.discord_accounts.upsertDiscordAccount({
 					account: author,
 				}),
-			{ concurrency: 10 },
+			{ concurrency: IndexingConfig.authorConcurrency },
 		);
+	});
 
-		const allAttachments = Arr.flatMap(humanMessages, (msg) =>
+const upsertMessages = (
+	aoMessages: Awaited<ReturnType<typeof toAOMessage>>[],
+) =>
+	Effect.gen(function* () {
+		const database = yield* Database;
+
+		yield* Effect.forEach(
+			aoMessages,
+			(data) =>
+				pipe(
+					database.private.messages.upsertMessage({
+						...toUpsertMessageArgs(data),
+						ignoreChecks: false,
+					}),
+					Effect.tapError((error) =>
+						Effect.logWarning(`Failed to upsert message: ${error}`),
+					),
+					Effect.ignore,
+				),
+			{ concurrency: IndexingConfig.messageConcurrency },
+		);
+	});
+
+const uploadMediaAssets = (humanMessages: Message[], channelId: string) =>
+	Effect.gen(function* () {
+		const attachments = Arr.flatMap(humanMessages, (msg) =>
 			Arr.map(Arr.fromIterable(msg.attachments.values()), (att) => ({
 				id: att.id,
 				url: att.url,
@@ -199,439 +344,366 @@ function storeMessages(
 			})),
 		);
 
-		yield* Effect.forEach(
-			aoMessages,
-			(data) =>
-				database.private.messages.upsertMessage({
-					...toUpsertMessageArgs(data),
-					ignoreChecks: false,
-				}),
-			{ concurrency: 5 },
-		);
-
-		if (allAttachments.length > 0) {
-			yield* uploadAttachmentsInBatches(allAttachments);
+		if (attachments.length > 0) {
+			yield* uploadAttachmentsInBatches(attachments);
 		}
 
-		const allEmbedImages = Arr.flatMap(humanMessages, (msg) =>
-			extractEmbedImagesToUpload(msg),
-		);
+		const embedImages = Arr.flatMap(humanMessages, extractEmbedImagesToUpload);
 
-		if (allEmbedImages.length > 0) {
-			yield* uploadEmbedImagesInBatches(allEmbedImages).pipe(
-				Effect.catchAll((error) =>
-					Console.warn(
-						`Failed to upload embed images for channel ${channelId}:`,
-						error,
+		if (embedImages.length > 0) {
+			yield* pipe(
+				uploadEmbedImagesInBatches(embedImages),
+				Effect.tapError((error) =>
+					Effect.logWarning(
+						`Failed to upload embed images for channel ${channelId}: ${error}`,
 					),
 				),
+				Effect.ignore,
 			);
 		}
+	});
 
-		if (humanMessages.length > 0) {
-			const lastMessage = humanMessages[humanMessages.length - 1];
-			if (lastMessage) {
-				const channelLiveData =
-					yield* database.private.channels.findChannelByDiscordId({
-						discordId: BigInt(channelId),
-					});
-				yield* Effect.sleep(Duration.millis(10));
-				const currentChannel = channelLiveData;
+const updateLastIndexedSnowflake = (channelId: string, lastMessageId: string) =>
+	Effect.gen(function* () {
+		const database = yield* Database;
 
-				if (currentChannel) {
-					const oldLastIndexed = currentChannel.flags?.lastIndexedSnowflake;
-					const newLastIndexedBigInt = BigInt(lastMessage.id);
+		const channel = yield* database.private.channels.findChannelByDiscordId({
+			discordId: BigInt(channelId),
+		});
 
-					yield* Effect.logDebug(
-						`Updating lastIndexedSnowflake for channel ${channelId}: ${oldLastIndexed ?? "null"} -> ${newLastIndexedBigInt}`,
-					);
-
-					yield* database.private.channels.updateChannelSettings({
-						channelId: BigInt(channelId),
-						settings: {
-							lastIndexedSnowflake: newLastIndexedBigInt,
-						},
-					});
-
-					yield* Effect.logDebug(
-						`Successfully updated lastIndexedSnowflake for channel ${channelId}`,
-					);
-				} else {
-					yield* Effect.logDebug(
-						`Warning: Could not update lastIndexedSnowflake for channel ${channelId} - channel not found in database`,
-					);
-				}
-			}
-		} else {
-			yield* Effect.logDebug(
-				`No messages to store, skipping lastIndexedSnowflake update for channel ${channelId}`,
+		if (!channel) {
+			yield* Effect.logWarning(
+				`Could not update lastIndexedSnowflake - channel ${channelId} not found`,
 			);
+			return;
+		}
+
+		const oldValue = channel.flags?.lastIndexedSnowflake;
+		const newValue = BigInt(lastMessageId);
+
+		yield* Effect.logDebug(
+			`Updating lastIndexedSnowflake for ${channelId}: ${oldValue ?? "null"} -> ${newValue}`,
+		);
+
+		yield* database.private.channels.updateChannelSettings({
+			channelId: BigInt(channelId),
+			settings: { lastIndexedSnowflake: newValue },
+		});
+	});
+
+const storeMessages = (
+	messages: Message[],
+	discordServerId: string,
+	channelId: string,
+) =>
+	Effect.gen(function* () {
+		if (messages.length === 0) {
+			yield* Effect.logDebug(`No messages to store for channel ${channelId}`);
+			return;
+		}
+
+		const { humanMessages, aoMessages } = yield* convertAndFilterMessages(
+			messages,
+			discordServerId,
+		);
+
+		yield* Effect.logDebug(
+			`Storing ${humanMessages.length} human messages (${messages.length} total)`,
+		);
+
+		yield* Effect.all(
+			[upsertAuthors(humanMessages), upsertMessages(aoMessages)],
+			{ concurrency: 2 },
+		);
+
+		yield* uploadMediaAssets(humanMessages, channelId);
+
+		const lastMessage = Arr.last(humanMessages);
+		if (Option.isSome(lastMessage)) {
+			yield* updateLastIndexedSnowflake(channelId, lastMessage.value.id);
 		}
 
 		yield* Effect.logDebug(`Successfully stored ${aoMessages.length} messages`);
 	});
-}
 
-function indexTextChannel(
-	channel: TextChannel | NewsChannel,
-	discordServerId: string,
-) {
-	return Effect.gen(function* () {
+const indexThread = (thread: AnyThreadChannel, discordServerId: string) =>
+	Effect.gen(function* () {
 		const database = yield* Database;
 
-		const channelLiveData =
-			yield* database.private.channels.findChannelByDiscordId({
-				discordId: BigInt(channel.id),
-			});
-		yield* Effect.sleep(Duration.millis(10));
-		const channelSettings = channelLiveData;
+		yield* syncChannel(thread);
 
-		if (!channelSettings?.flags.indexingEnabled) {
+		const threadChannel =
+			yield* database.private.channels.findChannelByDiscordId({
+				discordId: BigInt(thread.id),
+			});
+
+		const lastIndexed = threadChannel?.flags?.lastIndexedSnowflake;
+
+		const messages = yield* fetchChannelMessages(
+			thread.id,
+			thread.name,
+			lastIndexed?.toString(),
+		);
+
+		yield* storeMessages(messages, discordServerId, thread.id);
+	}).pipe(
+		Effect.tapErrorCause((cause) =>
+			Effect.logError(
+				`Error indexing thread ${thread.name} (${thread.id}): ${Cause.pretty(cause)}`,
+			),
+		),
+		Effect.ignore,
+	);
+
+const indexTextChannel = (
+	channel: TextChannel | NewsChannel,
+	discordServerId: string,
+) =>
+	Effect.gen(function* () {
+		const database = yield* Database;
+
+		const channelData = yield* database.private.channels.findChannelByDiscordId(
+			{
+				discordId: BigInt(channel.id),
+			},
+		);
+
+		if (!channelData?.flags.indexingEnabled) {
 			return;
 		}
 
-		const lastIndexedSnowflake = channelSettings.flags.lastIndexedSnowflake;
+		yield* ensureInviteCode(channel, channelData.flags.inviteCode);
+
+		const lastIndexed = channelData.flags.lastIndexedSnowflake;
 		yield* Effect.logDebug(
-			`Indexing text channel ${channel.name} (${channel.id}) - lastIndexedSnowflake: ${lastIndexedSnowflake ?? "null (starting from beginning)"}`,
+			`Indexing text channel ${channel.name} (${channel.id}) - last: ${lastIndexed ?? "beginning"}`,
 		);
 
 		const messages = yield* fetchChannelMessages(
 			channel.id,
 			channel.name,
-			lastIndexedSnowflake?.toString() ?? undefined,
+			lastIndexed?.toString(),
 		);
 
 		if (messages.length > 0) {
-			const firstMessageId = messages[0]?.id;
-			const lastMessageId = messages[messages.length - 1]?.id;
-			yield* Effect.logDebug(
-				`Fetched messages range: ${firstMessageId} to ${lastMessageId} (${messages.length} total)`,
-			);
-		} else {
-			yield* Effect.logDebug(
-				`No new messages found after ${lastIndexedSnowflake ?? "beginning"}`,
-			);
+			const first = messages[0]?.id;
+			const last = messages[messages.length - 1]?.id;
+			yield* Effect.logDebug(`Fetched messages range: ${first} to ${last}`);
 		}
 
 		yield* storeMessages(messages, discordServerId, channel.id);
 
-		const threadsToIndex = Arr.filter(
-			Arr.map(messages, (msg) => msg.thread),
-			(thread): thread is AnyThreadChannel =>
-				thread !== null &&
-				thread !== undefined &&
-				(thread.type === ChannelType.PublicThread ||
-					thread.type === ChannelType.AnnouncementThread),
+		const threads = pipe(
+			messages,
+			Arr.map((msg) => msg.thread),
+			Arr.filter(
+				(thread): thread is AnyThreadChannel =>
+					thread !== null && thread !== undefined && isIndexableThread(thread),
+			),
 		);
 
-		if (threadsToIndex.length > 0) {
+		if (threads.length > 0) {
 			yield* Effect.logDebug(
-				`Found ${threadsToIndex.length} threads to index in channel ${channel.name}`,
+				`Found ${threads.length} threads to index in ${channel.name}`,
 			);
 
 			yield* Effect.forEach(
-				threadsToIndex,
-				(thread) =>
-					Effect.gen(function* () {
-						yield* syncChannel(thread);
-
-						const threadChannelLiveData =
-							yield* database.private.channels.findChannelByDiscordId({
-								discordId: BigInt(thread.id),
-							});
-						yield* Effect.sleep(Duration.millis(10));
-						const threadChannel = threadChannelLiveData;
-						const threadLastIndexed =
-							threadChannel?.flags?.lastIndexedSnowflake;
-
-						const threadMessages = yield* fetchChannelMessages(
-							thread.id,
-							thread.name,
-							threadLastIndexed?.toString() ?? undefined,
-						);
-						yield* storeMessages(threadMessages, discordServerId, thread.id);
-					}).pipe(
-						Effect.catchAll((error) =>
-							Console.error(
-								`Error indexing thread ${thread.name} (${thread.id}):`,
-								error,
-							),
-						),
-					),
-				{ concurrency: 3 },
+				threads,
+				(thread) => indexThread(thread, discordServerId),
+				{ concurrency: IndexingConfig.threadConcurrency },
 			);
 		}
 	});
-}
 
-function indexForumChannel(channel: ForumChannel, discordServerId: string) {
-	return Effect.gen(function* () {
+const indexForumChannel = (channel: ForumChannel, discordServerId: string) =>
+	Effect.gen(function* () {
 		const database = yield* Database;
 
-		const channelLiveData =
-			yield* database.private.channels.findChannelByDiscordId({
+		const channelData = yield* database.private.channels.findChannelByDiscordId(
+			{
 				discordId: BigInt(channel.id),
-			});
-		yield* Effect.sleep(Duration.millis(10));
-		const channelSettings = channelLiveData;
+			},
+		);
 
-		if (!channelSettings?.flags.indexingEnabled) {
+		if (!channelData?.flags.indexingEnabled) {
 			return;
 		}
 
-		const lastIndexedSnowflake = channelSettings.flags.lastIndexedSnowflake;
+		yield* ensureInviteCode(channel, channelData.flags.inviteCode);
+
+		const lastIndexed = channelData.flags.lastIndexedSnowflake;
 		yield* Effect.logDebug(
-			`Indexing forum ${channel.name} (${channel.id}) - lastIndexedSnowflake: ${lastIndexedSnowflake ?? "null"}`,
+			`Indexing forum ${channel.name} (${channel.id}) - last: ${lastIndexed ?? "null"}`,
 		);
 
-		const threads = yield* fetchForumThreads(channel.id, channel.name);
+		const allThreads = yield* fetchForumThreads(channel.id, channel.name);
 
-		const threadsToIndex = lastIndexedSnowflake
-			? Arr.filter(
-					threads,
-					(thread) => BigInt(thread.id) > lastIndexedSnowflake,
-				)
-			: threads;
+		const threadsToIndex = lastIndexed
+			? Arr.filter(allThreads, (t) => BigInt(t.id) > lastIndexed)
+			: allThreads;
 
 		yield* Effect.logDebug(
-			`Found ${threads.length} total threads, ${threadsToIndex.length} new threads to index (filtered by lastIndexedSnowflake: ${lastIndexedSnowflake ?? "null"})`,
+			`${allThreads.length} total, ${threadsToIndex.length} new threads to index`,
 		);
 
 		yield* Effect.forEach(
 			threadsToIndex,
 			(thread) =>
-				Effect.gen(function* () {
-					yield* syncChannel(thread);
-
-					const threadChannelLiveData =
-						yield* database.private.channels.findChannelByDiscordId({
-							discordId: BigInt(thread.id),
-						});
-					yield* Effect.sleep(Duration.millis(10));
-					const threadChannel = threadChannelLiveData;
-					const threadLastIndexed = threadChannel?.flags?.lastIndexedSnowflake;
-
-					const threadMessages = yield* fetchChannelMessages(
-						thread.id,
-						thread.name,
-						threadLastIndexed?.toString() ?? undefined,
-					);
-					yield* storeMessages(threadMessages, discordServerId, thread.id);
-
-					yield* Effect.sleep(INDEXING_CONFIG.channelProcessDelay);
-				}).pipe(
-					Effect.catchAll((error) =>
-						Console.error(
-							`Error indexing thread ${thread.name} (${thread.id}):`,
-							error,
-						),
-					),
+				pipe(
+					indexThread(thread, discordServerId),
+					Effect.zipRight(Effect.sleep(IndexingConfig.channelProcessDelay)),
 				),
 			{ concurrency: 2 },
 		);
 
-		if (threads.length > 0) {
-			const sortedThreads = Arr.sort(
-				threads,
-				Order.reverse(
-					Order.mapInput(BigIntEffect.Order, (thread: AnyThreadChannel) =>
-						BigInt(thread.id),
-					),
-				),
-			);
-			const latestThread = sortedThreads[0];
-			if (latestThread) {
-				const channelLiveData =
-					yield* database.private.channels.findChannelByDiscordId({
-						discordId: BigInt(channel.id),
-					});
-				yield* Effect.sleep(Duration.millis(10));
-				const currentChannel = channelLiveData;
+		if (allThreads.length > 0) {
+			const sorted = Arr.sort(allThreads, byThreadSnowflakeDesc);
+			const latest = Arr.head(sorted);
 
-				if (currentChannel) {
-					const oldLastIndexed = currentChannel.flags?.lastIndexedSnowflake;
-					const newLastIndexedBigInt = BigInt(latestThread.id);
-
-					yield* Effect.logDebug(
-						`Updating forum lastIndexedSnowflake for ${channel.name} (${channel.id}): ${oldLastIndexed ?? "null"} -> ${newLastIndexedBigInt} (latest thread: ${latestThread.name})`,
-					);
-
-					yield* database.private.channels.updateChannelSettings({
-						channelId: BigInt(channel.id),
-						settings: {
-							lastIndexedSnowflake: newLastIndexedBigInt,
-						},
-					});
-
-					yield* Effect.logDebug(
-						`Successfully updated forum lastIndexedSnowflake for ${channel.name}`,
-					);
-				} else {
-					yield* Effect.logDebug(
-						`Warning: Could not update lastIndexedSnowflake for forum ${channel.id} - channel not found in database`,
-					);
-				}
+			if (Option.isSome(latest)) {
+				yield* updateLastIndexedSnowflake(channel.id, latest.value.id);
 			}
-		} else {
-			yield* Effect.logDebug(
-				`No threads found, skipping lastIndexedSnowflake update for forum ${channel.name}`,
-			);
 		}
 	});
-}
 
-function indexGuild(guild: Guild) {
-	return Effect.gen(function* () {
-		yield* Effect.logDebug(
+const indexGuild = (guild: Guild) =>
+	Effect.gen(function* () {
+		yield* Effect.logInfo(
 			`Starting indexing for guild: ${guild.name} (${guild.id})`,
 		);
 
 		const database = yield* Database;
 
-		const serverLiveData = yield* database.private.servers.getServerByDiscordId(
-			{
-				discordId: BigInt(guild.id),
-			},
-		);
-		yield* Effect.sleep(Duration.millis(10));
-		const server = serverLiveData;
+		const server = yield* database.private.servers.getServerByDiscordId({
+			discordId: BigInt(guild.id),
+		});
 
 		if (!server) {
-			yield* Console.warn(`Server ${guild.id} not found in database, skipping`);
+			yield* Effect.logWarning(
+				`Server ${guild.id} not found in database, skipping`,
+			);
 			return;
 		}
 
-		const channels = Arr.fromIterable(guild.channels.cache.values());
-
-		const indexableChannels = Arr.filter(
-			channels,
-			(channel) =>
-				channel.type === ChannelType.GuildText ||
-				channel.type === ChannelType.GuildAnnouncement ||
-				channel.type === ChannelType.GuildForum,
+		const channels = pipe(
+			Arr.fromIterable(guild.channels.cache.values()),
+			Arr.filter(isIndexableChannel),
 		);
 
 		yield* Effect.logDebug(
-			`Found ${indexableChannels.length} indexable channels in ${guild.name}`,
+			`Found ${channels.length} indexable channels in ${guild.name}`,
 		);
 
 		yield* Effect.forEach(
-			indexableChannels,
+			channels,
 			(channel: Channel) =>
-				Effect.gen(function* () {
-					if (channel.type === ChannelType.GuildForum) {
-						yield* indexForumChannel(
-							channel as ForumChannel,
-							server.discordId.toString(),
+				pipe(
+					channel.type === ChannelType.GuildForum
+						? indexForumChannel(
+								channel as ForumChannel,
+								server.discordId.toString(),
+							)
+						: indexTextChannel(
+								channel as TextChannel | NewsChannel,
+								server.discordId.toString(),
+							),
+					Effect.zipRight(Effect.sleep(IndexingConfig.channelProcessDelay)),
+					Effect.tapErrorCause((cause) => {
+						const name = channel.isDMBased()
+							? channel.id
+							: (channel as TextChannel).name;
+						return Effect.logError(
+							`Error indexing channel ${name}: ${Cause.pretty(cause)}`,
 						);
-					} else if (
-						channel.type === ChannelType.GuildText ||
-						channel.type === ChannelType.GuildAnnouncement
-					) {
-						yield* indexTextChannel(
-							channel as TextChannel | NewsChannel,
-							server.discordId.toString(),
-						);
-					}
-
-					yield* Effect.sleep(INDEXING_CONFIG.channelProcessDelay);
-				}).pipe(
-					Effect.catchAll((error) => {
-						const channelId = channel.isDMBased() ? channel.id : channel.name;
-						return Console.error(`Error indexing channel ${channelId}:`, error);
 					}),
+					Effect.ignore,
 				),
-			{ concurrency: 2 },
+			{ concurrency: IndexingConfig.channelConcurrency },
 		);
 
-		yield* Effect.logDebug(`Completed indexing for guild: ${guild.name}`);
+		yield* Effect.logInfo(`Completed indexing for guild: ${guild.name}`);
 	});
-}
 
-function runIndexing() {
-	return Effect.gen(function* () {
-		const discord = yield* Discord;
-		const startTime = yield* Clock.currentTimeMillis;
-		yield* Console.log("=== Starting indexing run ===");
-		yield* Effect.logDebug("=== Starting indexing run ===");
+const runIndexing = Effect.gen(function* () {
+	const discord = yield* Discord;
+	const startTime = yield* Clock.currentTimeMillis;
 
-		const guilds = yield* discord.getGuilds();
-		yield* Console.log(`Found ${guilds.length} guilds to index`);
-		yield* Effect.logDebug(`Found ${guilds.length} guilds to index`);
+	yield* Effect.logInfo("=== Starting indexing run ===");
 
-		yield* Effect.forEach(
-			guilds,
-			(guild) =>
-				Effect.gen(function* () {
-					yield* indexGuild(guild);
-					yield* Effect.sleep(INDEXING_CONFIG.guildProcessDelay);
-				}).pipe(
-					Effect.catchAll((error) =>
-						Console.error(`Error indexing guild ${guild.name}:`, error),
+	const guilds = yield* discord.getGuilds();
+	yield* Effect.logInfo(`Found ${guilds.length} guilds to index`);
+
+	yield* Effect.forEach(
+		guilds,
+		(guild) =>
+			pipe(
+				indexGuild(guild),
+				Effect.zipRight(Effect.sleep(IndexingConfig.guildProcessDelay)),
+				Effect.tapErrorCause((cause) =>
+					Effect.logError(
+						`Error indexing guild ${guild.name}: ${Cause.pretty(cause)}`,
 					),
 				),
-			{ concurrency: 1 },
-		);
-
-		const endTime = yield* Clock.currentTimeMillis;
-		const duration = endTime - startTime;
-		const hours = Math.floor(duration / 1000 / 60 / 60);
-		const minutes = Math.floor((duration / 1000 / 60) % 60);
-		const seconds = Math.floor((duration / 1000) % 60);
-
-		yield* Effect.logDebug(
-			`=== Indexing complete - took ${hours}h ${minutes}m ${seconds}s ===`,
-		);
-	}).pipe(
-		Effect.catchAll((error) =>
-			Console.error("Fatal error during indexing:", error),
-		),
+				Effect.ignore,
+			),
+		{ concurrency: 1 },
 	);
-}
 
-export function startIndexingLoop(runImmediately = true) {
-	return Effect.gen(function* () {
-		yield* Effect.logDebug(
-			`Starting indexing loop - will run every ${INDEXING_CONFIG.scheduleInterval}`,
+	const endTime = yield* Clock.currentTimeMillis;
+	const duration = Duration.millis(endTime - startTime);
+	const formatted = Duration.format(duration);
+
+	yield* Effect.logInfo(`=== Indexing complete - took ${formatted} ===`);
+});
+
+export const startIndexingLoop = (runImmediately = true) =>
+	Effect.gen(function* () {
+		yield* Effect.logInfo(
+			`Starting indexing loop - will run every ${Duration.format(IndexingConfig.scheduleInterval)}`,
 		);
 
 		if (runImmediately) {
 			yield* Effect.logDebug("Running initial indexing...");
-			yield* runIndexing().pipe(
-				Effect.catchAllCause((cause) =>
-					Console.error("Error during initial indexing run:", cause),
+			yield* pipe(
+				runIndexing,
+				Effect.tapErrorCause((cause) =>
+					Effect.logError(
+						`Error during initial indexing: ${Cause.pretty(cause)}`,
+					),
 				),
+				Effect.ignore,
 			);
 		}
 
-		const schedule = Schedule.fixed(INDEXING_CONFIG.scheduleInterval);
-
-		yield* Effect.fork(
-			Effect.repeat(runIndexing(), schedule).pipe(
-				Effect.catchAllCause((cause) =>
-					Console.error("Error in scheduled indexing run:", cause),
-				),
+		yield* pipe(
+			runIndexing,
+			Effect.repeat(Schedule.fixed(IndexingConfig.scheduleInterval)),
+			Effect.tapErrorCause((cause) =>
+				Effect.logError(`Error in scheduled indexing: ${Cause.pretty(cause)}`),
 			),
+			Effect.ignore,
+			Effect.fork,
 		);
 
-		yield* Effect.logDebug("Indexing loop started successfully");
+		yield* Effect.logInfo("Indexing loop started successfully");
 	});
-}
 
 export const IndexingHandlerLayer = Layer.scopedDiscard(
 	Effect.gen(function* () {
 		const discord = yield* Discord;
 
 		yield* discord.client.on("clientReady", () =>
-			Effect.gen(function* () {
-				yield* Console.log("Starting indexing loop...");
-				yield* startIndexingLoop(true).pipe(
-					Effect.tap(() => Console.log("Indexing loop started")),
-					Effect.catchAllCause((cause) =>
-						Console.error("Error starting indexing loop:", cause),
+			pipe(
+				Effect.logInfo("Starting indexing loop..."),
+				Effect.zipRight(startIndexingLoop(true)),
+				Effect.tap(() => Effect.logInfo("Indexing loop started")),
+				Effect.tapErrorCause((cause) =>
+					Effect.logError(
+						`Error starting indexing loop: ${Cause.pretty(cause)}`,
 					),
-				);
-			}),
+				),
+				Effect.ignore,
+			),
 		);
 	}),
 );

--- a/apps/discord-bot/src/utils/message-utils.ts
+++ b/apps/discord-bot/src/utils/message-utils.ts
@@ -3,6 +3,7 @@ import type { Message } from "discord.js";
 export function isHumanMessage(message: Message): boolean {
 	if (message.author.bot) return false;
 	if (message.author.system) return false;
+	if (message.system) return false;
 	return true;
 }
 


### PR DESCRIPTION
## Summary

- Refactor the Discord bot indexing service to use Effect-idiomatic patterns for better readability, resilience, and maintainability
- Add missing functionality: auto-create invite codes when indexing is enabled (matches old codebase behavior)
- Fix bug: filter system messages by adding `message.system` check to `isHumanMessage`

## Key Changes

### Effect Improvements
- **`Effect.iterate`** for pagination instead of while loops with mutable state
- **`Data.TaggedError`** for typed errors (`IndexingError`)
- **`Option`** for optional values (`lastMessage`, `inviteCode`)
- **`Cause.pretty`** for structured error logging
- **`pipe` composition** for cleaner data flow
- **Centralized config** with `Duration` types

### Code Organization
- Extract reusable `Order` comparators (`bySnowflakeAsc`, `byThreadSnowflakeDesc`)
- Extract type guards (`isIndexableThread`, `isIndexableChannel`)
- Decompose into small, composable functions:
  - `convertAndFilterMessages`
  - `upsertAuthors`
  - `upsertMessages`
  - `uploadMediaAssets`
  - `updateLastIndexedSnowflake`
  - `indexThread`

### Bug Fixes
- Add `message.system` check to filter Discord system messages (join notifications, etc.)
- Add `ensureInviteCode` to create permanent invites for indexed channels (needed for "Join Server" buttons)