### PR TITLE
Use tsgo for per-package type checking

### DIFF
--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "bun run --env-file=../../.env --watch index.dev.ts",
 		"start": "bun run --env-file=../../.env index.ts",
-		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"typecheck": "tsgo -p tsconfig.json --noEmit",
 		"clean": "rm -rf node_modules .turbo",
 		"test": "vitest run --no-watch --pool=forks",
 		"test:watch": "vitest"

--- a/apps/main-site/package.json
+++ b/apps/main-site/package.json
@@ -11,7 +11,7 @@
 		"dev": "bun run dev-next & bun run dev-proxy; wait",
 		"build": "bun with-env next build",
 		"start": "bun with-env next start",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"clean": "rm -rf node_modules .next"
 	},
 	"dependencies": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -17,7 +17,7 @@
 		"generate-function-types": "bun run scripts/generate-function-types.ts",
 		"generate-function-types:watch": "chokidar \"convex/{public,authenticated,private}/**/*.ts\" -c \"bun run scripts/generate-function-types.ts\"",
 		"dev": "bun run scripts/dev.ts",
-		"typecheck": "tsc -p convex/tsconfig.json --noEmit & tsc -p tsconfig.json --noEmit & wait",
+		"typecheck": "tsgo -p convex/tsconfig.json --noEmit & tsgo -p tsconfig.json --noEmit & wait",
 		"clean": "rm -rf node_modules .turbo",
 		"test": "vitest run --no-watch --pool=forks",
 		"test:watch": "vitest",

--- a/packages/discord-api/package.json
+++ b/packages/discord-api/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf node_modules .turbo",
-		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"typecheck": "tsgo -p tsconfig.json --noEmit",
 		"sync": "bun run scripts/sync-openapi.ts",
 		"gen": "mkdir -p src && openapi-gen --spec ./open-api.json > ./src/generated.ts",
 		"update": "bun run sync && bun run gen"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"clean": "rm -rf node_modules dist build .turbo",
-		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"typecheck": "tsgo -p tsconfig.json --noEmit",
 		"test": "vitest run --passWithNoTests --pool=forks",
 		"test:watch": "vitest --watch"
 	},


### PR DESCRIPTION
## Summary
- Replace `tsc` with `tsgo` in package typecheck scripts for ~10-20x faster type checking
- tsgo is Microsoft's native Go port of TypeScript (`@typescript/native-preview`)

## Packages Updated
- apps/discord-bot
- apps/main-site
- packages/database
- packages/discord-api
- packages/ui

## Notes
- `packages/convex-test` stays on `tsc` due to TS2742 errors with tsgo's declaration emit (still in preview)
- Individual packages work: tested each with `bun run typecheck`
- Root `tsgo --build --noEmit` also works (~10s)