### PR TITLE
Use HTTP client for main-site SSR to eliminate WebSocket timeout cliffs

### DIFF
--- a/apps/main-site/src/lib/runtime.ts
+++ b/apps/main-site/src/lib/runtime.ts
@@ -1,4 +1,4 @@
-import { DatabaseLayer } from "@packages/database/database";
+import { DatabaseHttpLayer } from "@packages/database/database";
 import { createOtelLayer } from "@packages/observability/effect-otel";
 import { ConfigProvider, Layer, ManagedRuntime } from "effect";
 
@@ -6,5 +6,5 @@ const OtelLayer = createOtelLayer("main-site");
 const ConfigProviderLayer = Layer.setConfigProvider(ConfigProvider.fromEnv());
 
 export const runtime = ManagedRuntime.make(
-	Layer.mergeAll(DatabaseLayer, OtelLayer, ConfigProviderLayer),
+	Layer.mergeAll(DatabaseHttpLayer, OtelLayer, ConfigProviderLayer),
 );

--- a/packages/database/src/convex-client-http.ts
+++ b/packages/database/src/convex-client-http.ts
@@ -1,0 +1,87 @@
+import { ConvexHttpClient } from "convex/browser";
+import type { FunctionReference } from "convex/server";
+import { Context, Duration, Effect, Layer } from "effect";
+import { api, internal } from "../convex/_generated/api";
+import {
+	type ConvexClientShared,
+	ConvexClientUnified,
+	ConvexError,
+	type WrappedUnifiedClient,
+} from "./convex-unified-client";
+
+const createHttpClient = (convexUrl: string): ConvexClientShared => {
+	const client = new ConvexHttpClient(convexUrl);
+	const noopUnsubscribe = Object.assign(() => {}, {
+		unsubscribe: () => {},
+		getCurrentValue: () => undefined,
+	});
+	return {
+		query: client.query.bind(client),
+		mutation: <Mutation extends FunctionReference<"mutation">>(
+			mutation: Mutation,
+			args: Parameters<typeof client.mutation>[1],
+		) => client.mutation(mutation, args),
+		action: client.action.bind(client),
+		onUpdate: () => noopUnsubscribe,
+	};
+};
+
+const createHttpService = Effect.gen(function* () {
+	const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL!;
+	const httpClient = createHttpClient(convexUrl);
+
+	const use = <A>(
+		fn: (
+			client: ConvexClientShared,
+			convexApi: {
+				api: typeof api;
+				internal: typeof internal;
+			},
+		) => A | Promise<A>,
+	) => {
+		return Effect.tryPromise({
+			try: () => Promise.resolve(fn(httpClient, { api, internal })),
+			catch: (cause) => new ConvexError({ cause }),
+		}).pipe(
+			Effect.timeoutFail({
+				duration: Duration.seconds(10),
+				onTimeout: () =>
+					new ConvexError({
+						cause: new Error("HTTP request timed out after 10s"),
+					}),
+			}),
+			Effect.withSpan("use_convex_http_client"),
+		) as Effect.Effect<Awaited<A>, ConvexError>;
+	};
+
+	return {
+		use,
+		httpClient,
+	};
+});
+
+export class ConvexClientHttp extends Context.Tag("ConvexClientHttp")<
+	ConvexClientHttp,
+	Effect.Effect.Success<typeof createHttpService>
+>() {}
+
+const ConvexClientHttpSharedLayer = Layer.effectContext(
+	Effect.gen(function* () {
+		const service = yield* createHttpService;
+		const unifiedService: WrappedUnifiedClient = {
+			client: service.httpClient,
+			use: service.use,
+		};
+		return Context.make(ConvexClientHttp, service).pipe(
+			Context.add(ConvexClientUnified, unifiedService),
+		);
+	}),
+);
+
+export const ConvexClientHttpLayer = Layer.service(ConvexClientHttp).pipe(
+	Layer.provide(ConvexClientHttpSharedLayer),
+);
+
+export const ConvexClientHttpUnifiedLayer = Layer.service(
+	ConvexClientUnified,
+).pipe(Layer.provide(ConvexClientHttpSharedLayer));

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -22,6 +22,7 @@ import {
 import { api, internal } from "../convex/_generated/api";
 import type { Emoji, Message } from "../convex/schema";
 import type { DatabaseAttachment } from "../convex/shared/shared";
+import { ConvexClientHttpUnifiedLayer } from "./convex-client-http";
 import { ConvexClientLiveUnifiedLayer } from "./convex-client-live";
 import { ConvexClientUnified, ConvexError } from "./convex-unified-client";
 import { FUNCTION_TYPE_MAP, isNamespace } from "./generated/function-types";
@@ -346,6 +347,10 @@ export class Database extends Context.Tag("Database")<
 
 export const DatabaseLayer = Layer.effect(Database, service).pipe(
 	Layer.provide(ConvexClientLiveUnifiedLayer),
+);
+
+export const DatabaseHttpLayer = Layer.effect(Database, service).pipe(
+	Layer.provide(ConvexClientHttpUnifiedLayer),
 );
 
 export type BaseMessageWithRelations = Message & {


### PR DESCRIPTION
## Summary

- Switches main-site server-side rendering from WebSocket to HTTP-only Convex client to eliminate timeout cliffs in serverless

## Problem

Investigation showed message pages hitting 15s/30s/45s timeout cliffs:
- **15s**: WebSocket connection timeout
- **30s**: HTTP fallback timeout  
- **45s**: Vercel function max timeout

With 700K+ unique pages/day and no persistent connections in serverless, WebSocket connection establishment was causing massive latency spikes.

## Solution

Created `DatabaseHttpLayer` using `ConvexHttpClient` directly:
- No WebSocket handshake overhead
- 10s timeout (vs 35s+ before)
- Same `ConvexClientUnified` interface via Effect's dependency injection

Long-running processes (discord-bot, migrations) still use WebSocket client where it makes sense.