### PR TITLE
refactor: centralize data access cache on ctx in custom functions

### DIFF
--- a/packages/database/convex/client/authenticated.ts
+++ b/packages/database/convex/client/authenticated.ts
@@ -8,6 +8,7 @@ import { api } from "../_generated/api";
 import type { ActionCtx, MutationCtx, QueryCtx } from "../_generated/server";
 import { action, query } from "../_generated/server";
 import { getDiscordAccountWithToken } from "../shared/auth";
+import { createDataAccessCache } from "../shared/dataAccess";
 import { DISCORD_PERMISSIONS, hasPermission } from "../shared/shared";
 import { mutation } from "../triggers";
 
@@ -29,8 +30,9 @@ export const authenticatedQuery = customQuery(query, {
 			throw new Error("Not authenticated or Discord account not linked");
 		}
 
+		const cache = createDataAccessCache(ctx);
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: {
 				...args,
 				discordAccountId,
@@ -50,8 +52,9 @@ export const authenticatedMutation = customMutation(mutation, {
 			throw new Error("Not authenticated or Discord account not linked");
 		}
 
+		const cache = createDataAccessCache(ctx);
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: {
 				...args,
 				discordAccountId,

--- a/packages/database/convex/client/guildManager.ts
+++ b/packages/database/convex/client/guildManager.ts
@@ -15,6 +15,7 @@ import {
 	query,
 } from "../_generated/server";
 import { getDiscordAccountWithToken } from "../shared/auth";
+import { createDataAccessCache } from "../shared/dataAccess";
 import {
 	assertGuildManagerPermission,
 	checkGuildManagerPermissions,
@@ -42,8 +43,9 @@ export const guildManagerQuery = customQuery(query, {
 			args.serverId,
 		);
 		assertGuildManagerPermission(permissionResult);
+		const cache = createDataAccessCache(ctx);
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: {
 				...args,
 				discordAccountId,
@@ -81,8 +83,9 @@ export const guildManagerMutation = customMutation(mutation, {
 			args.serverId,
 		);
 		assertGuildManagerPermission(permissionResult);
+		const cache = createDataAccessCache(ctx);
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: {
 				...args,
 				discordAccountId,

--- a/packages/database/convex/client/private.ts
+++ b/packages/database/convex/client/private.ts
@@ -5,6 +5,7 @@ import {
 	customQuery,
 } from "convex-helpers/server/customFunctions";
 import { action, query } from "../_generated/server";
+import { createDataAccessCache } from "../shared/dataAccess";
 import { mutation } from "../triggers";
 
 function validateBackendAccessToken(token: string | undefined): void {
@@ -25,11 +26,11 @@ export const privateQuery = customQuery(query, {
 	},
 	input: async (ctx, args) => {
 		validateBackendAccessToken(args.backendAccessToken);
-
+		const cache = createDataAccessCache(ctx);
 		const { backendAccessToken: _, ...handlerArgs } = args;
 
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: handlerArgs,
 		};
 	},
@@ -41,11 +42,11 @@ export const privateMutation = customMutation(mutation, {
 	},
 	input: async (ctx, args) => {
 		validateBackendAccessToken(args.backendAccessToken);
-
+		const cache = createDataAccessCache(ctx);
 		const { backendAccessToken: _, ...handlerArgs } = args;
 
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: handlerArgs,
 		};
 	},

--- a/packages/database/convex/public/custom_functions.ts
+++ b/packages/database/convex/public/custom_functions.ts
@@ -11,6 +11,7 @@ import {
 	getDiscordAccountWithToken,
 } from "../shared/auth";
 import { getAuthIdentity } from "../shared/authIdentity";
+import { createDataAccessCache } from "../shared/dataAccess";
 import { mutation } from "../triggers";
 
 function validateBackendAccessToken(token: string | undefined): boolean {
@@ -46,9 +47,11 @@ export const publicQuery = customQuery(query, {
 			args.backendAccessToken,
 		);
 
+		const cache = createDataAccessCache(ctx);
+
 		if (isBackendRequest) {
 			return {
-				ctx,
+				ctx: { ...ctx, cache },
 				args: {
 					...args,
 					rateLimitKey: "backend",
@@ -78,7 +81,7 @@ export const publicQuery = customQuery(query, {
 			throw new Error("Not discord account or anonymous session found");
 		}
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: {
 				...args,
 				rateLimitKey,
@@ -97,6 +100,7 @@ export const publicMutation = customMutation(mutation, {
 		type: v.optional(v.union(v.literal("signed-in"), v.literal("admin"))),
 	},
 	input: async (ctx, args) => {
+		const cache = createDataAccessCache(ctx);
 		let discordAccountId: bigint | undefined;
 		let type: "signed-in" | "admin";
 
@@ -118,7 +122,7 @@ export const publicMutation = customMutation(mutation, {
 		}
 
 		return {
-			ctx,
+			ctx: { ...ctx, cache },
 			args: {
 				...args,
 				discordAccountId,

--- a/packages/database/convex/shared/similarThreads.ts
+++ b/packages/database/convex/shared/similarThreads.ts
@@ -2,13 +2,12 @@ import { asyncMap } from "convex-helpers";
 import { getOneFrom } from "convex-helpers/server/relationships";
 import { Array as Arr, Predicate } from "effect";
 import type { Doc } from "../_generated/dataModel";
-import type { QueryCtx } from "../client";
 import { CHANNEL_TYPE } from "./channels";
-import { createDataAccessCache } from "./dataAccess";
+import type { QueryCtxWithCache } from "./dataAccess";
 import { getThreadStartMessage } from "./messages";
 
 export async function findSimilarThreads(
-	ctx: QueryCtx,
+	ctx: QueryCtxWithCache,
 	args: {
 		searchQuery: string;
 		currentThreadId: bigint;
@@ -124,10 +123,8 @@ export async function findSimilarThreads(
 		return thread !== undefined && thread.parentId !== null;
 	});
 
-	const cache = createDataAccessCache(ctx);
-
 	const firstMessages = await asyncMap(validThreadIds, async (idStr) => {
-		return getThreadStartMessage(cache, BigInt(idStr));
+		return getThreadStartMessage(ctx, BigInt(idStr));
 	});
 	return Arr.filter(firstMessages, Predicate.isNotNullable).slice(0, limit);
 }


### PR DESCRIPTION
## Summary

- Centralize cache creation in custom functions (`publicQuery`, `publicMutation`, `privateQuery`, `privateMutation`, etc.) so it's automatically available on `ctx.cache`
- Simplify helper function signatures by removing the separate `cache` parameter - functions now access cache via `ctx.cache`

## Changes

**Custom Functions Updated:**
- `publicQuery`, `publicMutation` (public/custom_functions.ts)
- `privateQuery`, `privateMutation` (client/private.ts)
- `authenticatedQuery`, `authenticatedMutation` (client/authenticated.ts)
- `guildManagerQuery`, `guildManagerMutation` (client/guildManager.ts)

**Helper Functions Simplified:**
- `enrichMessage(ctx, message)` - removed cache param
- `enrichMessages(ctx, messages)` - removed existingCache param
- `getThreadStartMessage(ctx, threadId)` - now uses ctx.cache
- `enrichMessageForDisplay(ctx, message, options?)` - removed cache from options
- `findSimilarThreads(ctx, args)` - now uses ctx.cache

**New Type:**
- `QueryCtxWithCache` - `BaseCtx & { cache: DataAccessCache }`

## Benefits

1. No more repetitive `const cache = createDataAccessCache(ctx)` in handlers
2. Simpler function signatures
3. Guaranteed cache availability for all handlers using these custom functions
4. Consistent caching pattern across the codebase

---
*Re-opened from #807 which was lost due to main branch history changes*