### PR TITLE
Centralize Link imports and disable prefetch

### DIFF
--- a/apps/main-site/src/app/(main-site)/blog/[slug]/page.tsx
+++ b/apps/main-site/src/app/(main-site)/blog/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { CodeBlock, InlineCode } from "@packages/ui/components/code";
 import type { Metadata } from "next";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@packages/ui/components/link";
 import { notFound } from "next/navigation";
 import React from "react";
 import { blog } from "@/.source/server";

--- a/apps/main-site/src/app/(main-site)/blog/page.tsx
+++ b/apps/main-site/src/app/(main-site)/blog/page.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader } from "@packages/ui/components/card";
 import type { Metadata } from "next";
-import Link from "next/link";
+import { Link } from "@packages/ui/components/link";
 import { blog } from "@/.source/server";
 import { formatDate, parseDate } from "@/lib/date-utils";
 

--- a/apps/main-site/src/components/blog-toc.tsx
+++ b/apps/main-site/src/components/blog-toc.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent } from "@packages/ui/components/card";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@packages/ui/components/link";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 

--- a/apps/main-site/src/components/server-card.tsx
+++ b/apps/main-site/src/components/server-card.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@packages/ui/components/button";
 import { ServerIcon } from "@packages/ui/components/server-icon";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@packages/ui/components/link";
 
 type ServerCardProps = {
 	server: {

--- a/packages/ui/src/components/link.tsx
+++ b/packages/ui/src/components/link.tsx
@@ -72,6 +72,7 @@ export function Link(
 		return (
 			<NextLink
 				scroll={true}
+				prefetch={false}
 				{...rest}
 				href={finalHref}
 				className={cn("flex flex-row items-center gap-2", className)}
@@ -80,5 +81,5 @@ export function Link(
 				{props.children}
 			</NextLink>
 		);
-	return <NextLink scroll={true} {...props} href={finalHref} />;
+	return <NextLink scroll={true} prefetch={false} {...props} href={finalHref} />;
 }

--- a/packages/ui/src/components/navbar/dashboard-navbar.tsx
+++ b/packages/ui/src/components/navbar/dashboard-navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PanelLeftIcon } from "lucide-react";
-import Link from "next/link";
+import { Link } from "../link";
 import * as React from "react";
 import { AnswerOverflowLogo } from "../answer-overflow-logo";
 import { Button } from "../button";

--- a/packages/ui/src/components/navbar/dashboard-sidebar.tsx
+++ b/packages/ui/src/components/navbar/dashboard-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { Link } from "../link";
 import { useParams, usePathname } from "next/navigation";
 import type * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/navbar/server-select-dropdown.tsx
+++ b/packages/ui/src/components/navbar/server-select-dropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, Plus } from "lucide-react";
-import Link from "next/link";
+import { Link } from "../link";
 import * as React from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "../button";


### PR DESCRIPTION
Update all files to use the centralized Link component from
@packages/ui instead of importing directly from next/link.
This ensures consistent behavior (tenant subpath handling,
external link security) and sets prefetch={false} by default.