### PR TITLE
vendor: add @packages/confect package

### DIFF
--- a/packages/confect/package.json
+++ b/packages/confect/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@packages/confect",
+	"version": "1.0.0",
+	"private": true,
+	"type": "module",
+	"exports": {
+		"./server": "./src/server/index.ts",
+		"./react": "./src/react/index.ts"
+	},
+	"dependencies": {
+		"@effect/platform": "catalog:",
+		"convex": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"typescript": "catalog:"
+	}
+}

--- a/packages/confect/src/react/index.ts
+++ b/packages/confect/src/react/index.ts
@@ -1,0 +1,87 @@
+import {
+	useAction as useConvexAction,
+	useMutation as useConvexMutation,
+	useQuery as useConvexQuery,
+} from "convex/react";
+import type { FunctionReference } from "convex/server";
+import { Effect, Option, Schema } from "effect";
+
+export const useQuery =
+	<Query extends FunctionReference<"query">, Args, Returns>({
+		query,
+		args,
+		returns,
+	}: {
+		query: Query;
+		args: Schema.Schema<Args, Query["_args"]>;
+		returns: Schema.Schema<Returns, Query["_returnType"]>;
+	}) =>
+	(actualArgs: Args): Option.Option<Returns> => {
+		const encodedArgs = Schema.encodeSync(args)(actualArgs);
+
+		const actualReturnsOrUndefined = useConvexQuery(query, encodedArgs);
+
+		if (actualReturnsOrUndefined === undefined) {
+			return Option.none();
+		} else {
+			const decodedReturns = Schema.decodeSync(returns)(
+				actualReturnsOrUndefined,
+			);
+
+			return Option.some(decodedReturns);
+		}
+	};
+
+export const useMutation = <
+	Mutation extends FunctionReference<"mutation">,
+	Args,
+	Returns,
+>({
+	mutation,
+	args,
+	returns,
+}: {
+	mutation: Mutation;
+	args: Schema.Schema<Args, Mutation["_args"]>;
+	returns: Schema.Schema<Returns, Mutation["_returnType"]>;
+}) => {
+	const actualMutation = useConvexMutation(mutation);
+
+	return (actualArgs: Args): Effect.Effect<Returns> =>
+		Effect.gen(function* () {
+			const encodedArgs = yield* Schema.encode(args)(actualArgs);
+
+			const actualReturns = yield* Effect.promise(() =>
+				actualMutation(encodedArgs),
+			);
+
+			return yield* Schema.decode(returns)(actualReturns);
+		}).pipe(Effect.orDie);
+};
+
+export const useAction = <
+	Action extends FunctionReference<"action">,
+	Args,
+	Returns,
+>({
+	action,
+	args,
+	returns,
+}: {
+	action: Action;
+	args: Schema.Schema<Args, Action["_args"]>;
+	returns: Schema.Schema<Returns, Action["_returnType"]>;
+}) => {
+	const actualAction = useConvexAction(action);
+
+	return (actualArgs: Args): Effect.Effect<Returns> =>
+		Effect.gen(function* () {
+			const encodedArgs = yield* Schema.encode(args)(actualArgs);
+
+			const actualReturns = yield* Effect.promise(() =>
+				actualAction(encodedArgs),
+			);
+
+			return yield* Schema.decode(returns)(actualReturns);
+		}).pipe(Effect.orDie);
+};

--- a/packages/confect/src/server/auth.ts
+++ b/packages/confect/src/server/auth.ts
@@ -1,0 +1,16 @@
+import type { Auth, UserIdentity } from "convex/server";
+import { Effect, Option, pipe } from "effect";
+
+export interface ConfectAuth {
+	getUserIdentity(): Effect.Effect<Option.Option<UserIdentity>>;
+}
+
+export class ConfectAuthImpl implements ConfectAuth {
+	constructor(private auth: Auth) {}
+	getUserIdentity(): Effect.Effect<Option.Option<UserIdentity>> {
+		return pipe(
+			Effect.promise(() => this.auth.getUserIdentity()),
+			Effect.map(Option.fromNullable),
+		);
+	}
+}

--- a/packages/confect/src/server/ctx.ts
+++ b/packages/confect/src/server/ctx.ts
@@ -1,0 +1,218 @@
+import type {
+	Expand,
+	FunctionReference,
+	FunctionReturnType,
+	GenericActionCtx,
+	GenericMutationCtx,
+	GenericQueryCtx,
+	NamedTableInfo,
+	OptionalRestArgs,
+	VectorIndexNames,
+	VectorSearchQuery,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import { Context, Effect } from "effect";
+
+import { type ConfectAuth, ConfectAuthImpl } from "./auth";
+import type {
+	DataModelFromConfectDataModel,
+	GenericConfectDataModel,
+	TableNamesInConfectDataModel,
+} from "./data-model";
+import {
+	type ConfectDatabaseReader,
+	ConfectDatabaseReaderImpl,
+	type ConfectDatabaseWriter,
+	ConfectDatabaseWriterImpl,
+	type DatabaseSchemasFromConfectDataModel,
+} from "./database";
+import { type ConfectScheduler, ConfectSchedulerImpl } from "./scheduler";
+import {
+	type ConfectStorageReader,
+	ConfectStorageReaderImpl,
+	type ConfectStorageWriter,
+	ConfectStorageWriterImpl,
+} from "./storage";
+
+export type ConfectMutationCtx<
+	ConfectDataModel extends GenericConfectDataModel,
+> = {
+	runQuery<Query extends FunctionReference<"query", "public" | "internal">>(
+		query: Query,
+		...args: OptionalRestArgs<Query>
+	): Effect.Effect<FunctionReturnType<Query>>;
+	runMutation<
+		Mutation extends FunctionReference<"mutation", "public" | "internal">,
+	>(
+		mutation: Mutation,
+		...args: OptionalRestArgs<Mutation>
+	): Effect.Effect<FunctionReturnType<Mutation>>;
+	ctx: GenericMutationCtx<DataModelFromConfectDataModel<ConfectDataModel>>;
+	db: ConfectDatabaseWriter<ConfectDataModel>;
+	auth: ConfectAuth;
+	storage: ConfectStorageWriter;
+	scheduler: ConfectScheduler;
+};
+
+export const ConfectMutationCtx = <
+	ConfectDataModel extends GenericConfectDataModel,
+>() =>
+	Context.GenericTag<ConfectMutationCtx<ConfectDataModel>>(
+		"@rjdellecese/confect/ConfectMutationCtx",
+	);
+
+export type ConfectQueryCtx<ConfectDataModel extends GenericConfectDataModel> =
+	{
+		runQuery<Query extends FunctionReference<"query", "public" | "internal">>(
+			query: Query,
+			...args: OptionalRestArgs<Query>
+		): Effect.Effect<FunctionReturnType<Query>>;
+		ctx: GenericQueryCtx<DataModelFromConfectDataModel<ConfectDataModel>>;
+		db: ConfectDatabaseReader<ConfectDataModel>;
+		auth: ConfectAuth;
+		storage: ConfectStorageReader;
+	};
+
+export const ConfectQueryCtx = <
+	ConfectDataModel extends GenericConfectDataModel,
+>() =>
+	Context.GenericTag<ConfectQueryCtx<ConfectDataModel>>(
+		"@rjdellecese/confect/ConfectQueryCtx",
+	);
+
+export type ConfectActionCtx<ConfectDataModel extends GenericConfectDataModel> =
+	{
+		runQuery<Query extends FunctionReference<"query", "public" | "internal">>(
+			query: Query,
+			...args: OptionalRestArgs<Query>
+		): Effect.Effect<FunctionReturnType<Query>>;
+		runMutation<
+			Mutation extends FunctionReference<"mutation", "public" | "internal">,
+		>(
+			mutation: Mutation,
+			...args: OptionalRestArgs<Mutation>
+		): Effect.Effect<FunctionReturnType<Mutation>>;
+		runAction<
+			Action extends FunctionReference<"action", "public" | "internal">,
+		>(
+			action: Action,
+			...args: OptionalRestArgs<Action>
+		): Effect.Effect<FunctionReturnType<Action>>;
+
+		ctx: GenericActionCtx<DataModelFromConfectDataModel<ConfectDataModel>>;
+		scheduler: ConfectScheduler;
+		auth: ConfectAuth;
+		storage: ConfectStorageWriter;
+		vectorSearch<
+			TableName extends TableNamesInConfectDataModel<ConfectDataModel>,
+			IndexName extends VectorIndexNames<
+				NamedTableInfo<
+					DataModelFromConfectDataModel<ConfectDataModel>,
+					TableName
+				>
+			>,
+		>(
+			tableName: TableName,
+			indexName: IndexName,
+			query: Expand<
+				VectorSearchQuery<
+					NamedTableInfo<
+						DataModelFromConfectDataModel<ConfectDataModel>,
+						TableName
+					>,
+					IndexName
+				>
+			>,
+		): Effect.Effect<Array<{ _id: GenericId<TableName>; _score: number }>>;
+	};
+
+export const ConfectActionCtx = <
+	ConfectDataModel extends GenericConfectDataModel,
+>() =>
+	Context.GenericTag<ConfectActionCtx<ConfectDataModel>>(
+		"@rjdellecese/confect/ConfectActionCtx",
+	);
+
+export const makeConfectQueryCtx = <
+	ConfectDataModel extends GenericConfectDataModel,
+>(
+	ctx: GenericQueryCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
+): ConfectQueryCtx<ConfectDataModel> => ({
+	runQuery: <Query extends FunctionReference<"query", "public" | "internal">>(
+		query: Query,
+		...queryArgs: OptionalRestArgs<Query>
+	) => Effect.promise(() => ctx.runQuery(query, ...queryArgs)),
+	ctx,
+	db: new ConfectDatabaseReaderImpl(ctx.db, databaseSchemas),
+	auth: new ConfectAuthImpl(ctx.auth),
+	storage: new ConfectStorageReaderImpl(ctx.storage),
+});
+
+export const makeConfectMutationCtx = <
+	ConfectDataModel extends GenericConfectDataModel,
+>(
+	ctx: GenericMutationCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
+): ConfectMutationCtx<ConfectDataModel> => ({
+	runQuery: <Query extends FunctionReference<"query", "public" | "internal">>(
+		query: Query,
+		...queryArgs: OptionalRestArgs<Query>
+	) => Effect.promise(() => ctx.runQuery(query, ...queryArgs)),
+	runMutation: <
+		Mutation extends FunctionReference<"mutation", "public" | "internal">,
+	>(
+		mutation: Mutation,
+		...mutationArgs: OptionalRestArgs<Mutation>
+	) => Effect.promise(() => ctx.runMutation(mutation, ...mutationArgs)),
+	ctx,
+	db: new ConfectDatabaseWriterImpl(ctx.db, databaseSchemas),
+	auth: new ConfectAuthImpl(ctx.auth),
+	storage: new ConfectStorageWriterImpl(ctx.storage),
+	scheduler: new ConfectSchedulerImpl(ctx.scheduler),
+});
+
+export const makeConfectActionCtx = <
+	ConfectDataModel extends GenericConfectDataModel,
+>(
+	ctx: GenericActionCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+): ConfectActionCtx<ConfectDataModel> => ({
+	runQuery: <Query extends FunctionReference<"query", "public" | "internal">>(
+		query: Query,
+		...queryArgs: OptionalRestArgs<Query>
+	) => Effect.promise(() => ctx.runQuery(query, ...queryArgs)),
+	runMutation: <
+		Mutation extends FunctionReference<"mutation", "public" | "internal">,
+	>(
+		mutation: Mutation,
+		...mutationArgs: OptionalRestArgs<Mutation>
+	) => Effect.promise(() => ctx.runMutation(mutation, ...mutationArgs)),
+	runAction: <
+		Action extends FunctionReference<"action", "public" | "internal">,
+	>(
+		action: Action,
+		...actionArgs: OptionalRestArgs<Action>
+	) => Effect.promise(() => ctx.runAction(action, ...actionArgs)),
+	vectorSearch: <
+		TableName extends TableNamesInConfectDataModel<ConfectDataModel>,
+		IndexName extends VectorIndexNames<
+			NamedTableInfo<DataModelFromConfectDataModel<ConfectDataModel>, TableName>
+		>,
+	>(
+		tableName: TableName,
+		indexName: IndexName,
+		query: Expand<
+			VectorSearchQuery<
+				NamedTableInfo<
+					DataModelFromConfectDataModel<ConfectDataModel>,
+					TableName
+				>,
+				IndexName
+			>
+		>,
+	) => Effect.promise(() => ctx.vectorSearch(tableName, indexName, query)),
+	ctx,
+	auth: new ConfectAuthImpl(ctx.auth),
+	storage: new ConfectStorageWriterImpl(ctx.storage),
+	scheduler: new ConfectSchedulerImpl(ctx.scheduler),
+});

--- a/packages/confect/src/server/data-model.ts
+++ b/packages/confect/src/server/data-model.ts
@@ -1,0 +1,63 @@
+import type {
+	GenericDocument,
+	GenericFieldPaths,
+	GenericTableIndexes,
+	GenericTableSearchIndexes,
+	GenericTableVectorIndexes,
+} from "convex/server";
+import type { ReadonlyRecord } from "effect/Record";
+import type { ReadonlyValue } from "./schema-to-validator";
+
+export type GenericConfectDocument = ReadonlyRecord<string, any>;
+
+export type GenericEncodedConfectDocument = ReadonlyRecord<
+	string,
+	ReadonlyValue
+>;
+
+export type ConfectDocumentByName<
+	ConfectDataModel extends GenericConfectDataModel,
+	TableName extends TableNamesInConfectDataModel<ConfectDataModel>,
+> = ConfectDataModel[TableName]["confectDocument"];
+
+export type GenericConfectDataModel = Record<string, GenericConfectTableInfo>;
+
+export type DataModelFromConfectDataModel<
+	ConfectDataModel extends GenericConfectDataModel,
+> = {
+	[TableName in keyof ConfectDataModel & string]: TableInfoFromConfectTableInfo<
+		ConfectDataModel[TableName]
+	>;
+};
+
+export type TableNamesInConfectDataModel<
+	ConfectDataModel extends GenericConfectDataModel,
+> = keyof ConfectDataModel & string;
+
+export type TableInfoFromConfectTableInfo<
+	ConfectTableInfo extends GenericConfectTableInfo,
+> = {
+	document: ConfectTableInfo["convexDocument"];
+	fieldPaths: ConfectTableInfo["fieldPaths"];
+	indexes: ConfectTableInfo["indexes"];
+	searchIndexes: ConfectTableInfo["searchIndexes"];
+	vectorIndexes: ConfectTableInfo["vectorIndexes"];
+};
+
+export type GenericConfectTableInfo = {
+	confectDocument: GenericConfectDocument;
+	encodedConfectDocument: GenericEncodedConfectDocument;
+	convexDocument: GenericDocument;
+	fieldPaths: GenericFieldPaths;
+	indexes: GenericTableIndexes;
+	searchIndexes: GenericTableSearchIndexes;
+	vectorIndexes: GenericTableVectorIndexes;
+};
+
+/**
+ * The Confect document encoded for storage in Convex. This is the data as it is stored in the database.
+ */
+export type ConfectDoc<
+	ConfectDataModel extends GenericConfectDataModel,
+	TableName extends TableNamesInConfectDataModel<ConfectDataModel>,
+> = ConfectDataModel[TableName]["encodedConfectDocument"];

--- a/packages/confect/src/server/database.ts
+++ b/packages/confect/src/server/database.ts
@@ -1,0 +1,746 @@
+import type {
+	BetterOmit,
+	DocumentByInfo,
+	DocumentByName,
+	Expand,
+	Expression,
+	FilterBuilder,
+	GenericDatabaseReader,
+	GenericDatabaseWriter,
+	GenericDataModel,
+	Indexes,
+	IndexRange,
+	IndexRangeBuilder,
+	NamedIndex,
+	NamedSearchIndex,
+	OrderedQuery,
+	PaginationOptions,
+	PaginationResult,
+	Query,
+	QueryInitializer,
+	SearchFilter,
+	SearchFilterBuilder,
+	SearchIndexes,
+	WithOptionalSystemFields,
+	WithoutSystemFields,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import {
+	Array,
+	type Cause,
+	Chunk,
+	Data,
+	Effect,
+	identity,
+	Option,
+	type ParseResult,
+	pipe,
+	Record,
+	Schema,
+	Stream,
+} from "effect";
+
+import type {
+	ConfectDocumentByName,
+	DataModelFromConfectDataModel,
+	GenericConfectDataModel,
+	GenericConfectDocument,
+	GenericConfectTableInfo,
+	GenericEncodedConfectDocument,
+	TableInfoFromConfectTableInfo,
+	TableNamesInConfectDataModel,
+} from "./data-model";
+import {
+	type ConfectDataModelFromConfectSchema,
+	type ConfectSystemDataModel,
+	confectSystemSchemaDefinition,
+	type GenericConfectSchema,
+} from "./schema";
+import { extendWithSystemFields } from "./schemas/SystemFields";
+
+interface ConfectQuery<
+	ConfectTableInfo extends GenericConfectTableInfo,
+	TableName extends string,
+> {
+	filter(
+		predicate: (
+			q: FilterBuilder<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+		) => Expression<boolean>,
+	): ConfectQuery<ConfectTableInfo, TableName>;
+	order(
+		order: "asc" | "desc",
+	): ConfectOrderedQuery<ConfectTableInfo, TableName>;
+	paginate(
+		paginationOpts: PaginationOptions,
+	): Effect.Effect<PaginationResult<ConfectTableInfo["confectDocument"]>>;
+	collect(): Effect.Effect<ConfectTableInfo["confectDocument"][]>;
+	take(n: number): Effect.Effect<ConfectTableInfo["confectDocument"][]>;
+	first(): Effect.Effect<Option.Option<ConfectTableInfo["confectDocument"]>>;
+	unique(): Effect.Effect<
+		Option.Option<ConfectTableInfo["confectDocument"]>,
+		NotUniqueError
+	>;
+	stream(): Stream.Stream<ConfectTableInfo["confectDocument"]>;
+}
+
+interface ConfectOrderedQuery<
+	ConfectTableInfo extends GenericConfectTableInfo,
+	TableName extends string,
+> extends Omit<ConfectQuery<ConfectTableInfo, TableName>, "order"> {}
+
+export class NotUniqueError extends Data.TaggedError("NotUniqueError") {}
+
+class ConfectQueryImpl<
+	ConfectTableInfo extends GenericConfectTableInfo,
+	TableName extends string,
+> implements ConfectQuery<ConfectTableInfo, TableName>
+{
+	q: Query<TableInfoFromConfectTableInfo<ConfectTableInfo>>;
+	tableSchema: Schema.Schema<
+		ConfectTableInfo["confectDocument"],
+		ConfectTableInfo["encodedConfectDocument"]
+	>;
+	tableName: TableName;
+	constructor(
+		q:
+			| Query<TableInfoFromConfectTableInfo<ConfectTableInfo>>
+			| OrderedQuery<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+		tableSchema: Schema.Schema<
+			ConfectTableInfo["confectDocument"],
+			ConfectTableInfo["encodedConfectDocument"]
+		>,
+		tableName: TableName,
+	) {
+		// This is some trickery, copied from convex-js. I suspect there's a better way.
+		this.q = q as Query<TableInfoFromConfectTableInfo<ConfectTableInfo>>;
+		this.tableSchema = tableSchema;
+		this.tableName = tableName;
+	}
+	decode(
+		convexDocument: ConfectTableInfo["encodedConfectDocument"],
+	): ConfectTableInfo["confectDocument"] {
+		return decodeDocument(this.tableName, this.tableSchema, convexDocument);
+	}
+	filter(
+		predicate: (
+			q: FilterBuilder<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+		) => Expression<boolean>,
+	) {
+		return new ConfectQueryImpl(
+			this.q.filter(predicate),
+			this.tableSchema,
+			this.tableName,
+		);
+	}
+	order(order: "asc" | "desc"): ConfectQueryImpl<ConfectTableInfo, TableName> {
+		return new ConfectQueryImpl(
+			this.q.order(order),
+			this.tableSchema,
+			this.tableName,
+		);
+	}
+	paginate(
+		paginationOpts: PaginationOptions,
+	): Effect.Effect<PaginationResult<ConfectTableInfo["confectDocument"]>> {
+		return pipe(
+			Effect.Do,
+			Effect.bind("paginationResult", () =>
+				Effect.promise(() => this.q.paginate(paginationOpts)),
+			),
+			Effect.let("parsedPage", ({ paginationResult }) =>
+				pipe(
+					paginationResult.page,
+					Array.map((document) => this.decode(document)),
+				),
+			),
+			Effect.map(({ paginationResult, parsedPage }) => ({
+				page: parsedPage,
+				isDone: paginationResult.isDone,
+				continueCursor: paginationResult.continueCursor,
+				/* v8 ignore next -- @preserve */
+				...(paginationResult.splitCursor
+					? { splitCursor: paginationResult.splitCursor }
+					: {}),
+				/* v8 ignore next -- @preserve */
+				...(paginationResult.pageStatus
+					? { pageStatus: paginationResult.pageStatus }
+					: {}),
+			})),
+		);
+	}
+	// It could be better to implement collect() with stream()
+	collect(): Effect.Effect<ConfectTableInfo["confectDocument"][]> {
+		return pipe(
+			Effect.promise(() => this.q.collect()),
+			Effect.map(Array.map((document) => this.decode(document))),
+		);
+	}
+	take(n: number): Effect.Effect<ConfectTableInfo["confectDocument"][]> {
+		return pipe(
+			this.stream(),
+			Stream.take(n),
+			Stream.runCollect,
+			Effect.map((chunk) => Chunk.toArray(chunk)),
+		);
+	}
+	first(): Effect.Effect<Option.Option<ConfectTableInfo["confectDocument"]>> {
+		return pipe(this.stream(), Stream.runHead);
+	}
+	unique(): Effect.Effect<
+		Option.Option<ConfectTableInfo["confectDocument"]>,
+		NotUniqueError
+	> {
+		return pipe(
+			this.stream(),
+			Stream.take(2),
+			Stream.runCollect,
+			Effect.andThen((chunk) =>
+				pipe(
+					chunk,
+					Chunk.get(1),
+					Option.match({
+						onSome: () => Effect.fail(new NotUniqueError()),
+						onNone: () => Effect.succeed(Chunk.get(chunk, 0)),
+					}),
+				),
+			),
+		);
+	}
+	stream(): Stream.Stream<ConfectTableInfo["confectDocument"]> {
+		return pipe(
+			Stream.fromAsyncIterable(this.q, identity),
+			Stream.map((document) => this.decode(document)),
+			Stream.orDie,
+		);
+	}
+}
+
+interface ConfectQueryInitializer<
+	ConfectTableInfo extends GenericConfectTableInfo,
+	TableName extends string,
+> extends ConfectQuery<ConfectTableInfo, TableName> {
+	fullTableScan(): ConfectQuery<ConfectTableInfo, TableName>;
+	withIndex<
+		IndexName extends keyof Indexes<
+			TableInfoFromConfectTableInfo<ConfectTableInfo>
+		>,
+	>(
+		indexName: IndexName,
+		indexRange?:
+			| ((
+					q: IndexRangeBuilder<
+						DocumentByInfo<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+						NamedIndex<
+							TableInfoFromConfectTableInfo<ConfectTableInfo>,
+							IndexName
+						>,
+						0
+					>,
+			  ) => IndexRange)
+			| undefined,
+	): ConfectQuery<ConfectTableInfo, TableName>;
+	withSearchIndex<
+		IndexName extends keyof SearchIndexes<
+			TableInfoFromConfectTableInfo<ConfectTableInfo>
+		>,
+	>(
+		indexName: IndexName,
+		searchFilter: (
+			q: SearchFilterBuilder<
+				DocumentByInfo<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+				NamedSearchIndex<
+					TableInfoFromConfectTableInfo<ConfectTableInfo>,
+					IndexName
+				>
+			>,
+		) => SearchFilter,
+	): ConfectOrderedQuery<ConfectTableInfo, TableName>;
+}
+
+class ConfectQueryInitializerImpl<
+	ConfectTableInfo extends GenericConfectTableInfo,
+	TableName extends string,
+> implements ConfectQueryInitializer<ConfectTableInfo, TableName>
+{
+	q: QueryInitializer<TableInfoFromConfectTableInfo<ConfectTableInfo>>;
+	tableSchema: Schema.Schema<
+		ConfectTableInfo["confectDocument"],
+		ConfectTableInfo["encodedConfectDocument"]
+	>;
+	tableName: TableName;
+	constructor(
+		q: QueryInitializer<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+		tableSchema: Schema.Schema<
+			ConfectTableInfo["confectDocument"],
+			ConfectTableInfo["encodedConfectDocument"]
+		>,
+		tableName: TableName,
+	) {
+		this.q = q;
+		this.tableSchema = tableSchema;
+		this.tableName = tableName;
+	}
+	fullTableScan(): ConfectQuery<ConfectTableInfo, TableName> {
+		return new ConfectQueryImpl(
+			this.q.fullTableScan(),
+			this.tableSchema,
+			this.tableName,
+		);
+	}
+	withIndex<
+		IndexName extends keyof Indexes<
+			TableInfoFromConfectTableInfo<ConfectTableInfo>
+		>,
+	>(
+		indexName: IndexName,
+		indexRange?:
+			| ((
+					q: IndexRangeBuilder<
+						DocumentByInfo<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+						NamedIndex<
+							TableInfoFromConfectTableInfo<ConfectTableInfo>,
+							IndexName
+						>,
+						0
+					>,
+			  ) => IndexRange)
+			| undefined,
+	): ConfectQuery<ConfectTableInfo, TableName> {
+		return new ConfectQueryImpl(
+			this.q.withIndex(indexName, indexRange),
+			this.tableSchema,
+			this.tableName,
+		);
+	}
+	withSearchIndex<
+		IndexName extends keyof SearchIndexes<
+			TableInfoFromConfectTableInfo<ConfectTableInfo>
+		>,
+	>(
+		indexName: IndexName,
+		searchFilter: (
+			q: SearchFilterBuilder<
+				DocumentByInfo<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+				NamedSearchIndex<
+					TableInfoFromConfectTableInfo<ConfectTableInfo>,
+					IndexName
+				>
+			>,
+		) => SearchFilter,
+	): ConfectOrderedQuery<ConfectTableInfo, TableName> {
+		return new ConfectQueryImpl(
+			this.q.withSearchIndex(indexName, searchFilter),
+			this.tableSchema,
+			this.tableName,
+		);
+	}
+	filter(
+		predicate: (
+			q: FilterBuilder<TableInfoFromConfectTableInfo<ConfectTableInfo>>,
+		) => Expression<boolean>,
+	): ConfectQuery<ConfectTableInfo, TableName> {
+		return this.fullTableScan().filter(predicate);
+	}
+	order(
+		order: "asc" | "desc",
+	): ConfectOrderedQuery<ConfectTableInfo, TableName> {
+		return this.fullTableScan().order(order);
+	}
+	paginate(
+		paginationOpts: PaginationOptions,
+	): Effect.Effect<PaginationResult<ConfectTableInfo["confectDocument"]>> {
+		return this.fullTableScan().paginate(paginationOpts);
+	}
+	collect(): Effect.Effect<ConfectTableInfo["confectDocument"][]> {
+		return this.fullTableScan().collect();
+	}
+	take(n: number): Effect.Effect<ConfectTableInfo["confectDocument"][]> {
+		return this.fullTableScan().take(n);
+	}
+	first(): Effect.Effect<Option.Option<ConfectTableInfo["confectDocument"]>> {
+		return this.fullTableScan().first();
+	}
+	unique(): Effect.Effect<
+		Option.Option<ConfectTableInfo["confectDocument"]>,
+		NotUniqueError
+	> {
+		return this.fullTableScan().unique();
+	}
+	stream(): Stream.Stream<ConfectTableInfo["confectDocument"]> {
+		return this.fullTableScan().stream();
+	}
+}
+
+export type DatabaseSchemasFromConfectDataModel<
+	ConfectDataModel extends GenericConfectDataModel,
+> = {
+	[TableName in keyof ConfectDataModel & string]: Schema.Schema<
+		ConfectDataModel[TableName]["confectDocument"],
+		ConfectDataModel[TableName]["encodedConfectDocument"]
+	>;
+};
+
+export interface ConfectDatabaseReader<
+	ConfectDataModel extends GenericConfectDataModel,
+> extends ConfectBaseDatabaseReader<ConfectDataModel> {
+	system: ConfectBaseDatabaseReader<ConfectSystemDataModel>;
+}
+
+export interface ConfectBaseDatabaseReader<
+	ConfectDataModel extends GenericConfectDataModel,
+> {
+	query<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+	): ConfectQueryInitializer<ConfectDataModel[TableName], TableName>;
+	get<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+	): Effect.Effect<
+		Option.Option<ConfectDataModel[TableName]["confectDocument"]>
+	>;
+	normalizeId<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		id: string,
+	): Option.Option<GenericId<TableName>>;
+}
+
+export class ConfectBaseDatabaseReaderImpl<
+	ConfectDataModel extends GenericConfectDataModel,
+> implements ConfectBaseDatabaseReader<ConfectDataModel>
+{
+	db: BaseDatabaseReader<DataModelFromConfectDataModel<ConfectDataModel>>;
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	constructor(
+		db: BaseDatabaseReader<DataModelFromConfectDataModel<ConfectDataModel>>,
+		databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
+	) {
+		this.db = db;
+		this.databaseSchemas = databaseSchemas;
+	}
+	decode<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		convexDocument: ConfectDataModel[TableName]["encodedConfectDocument"],
+	): ConfectDataModel[TableName]["confectDocument"] {
+		return decodeDocument(
+			tableName,
+			this.databaseSchemas[tableName],
+			convexDocument,
+		);
+	}
+	tableName(
+		id: GenericId<TableNamesInConfectDataModel<ConfectDataModel>>,
+	): Option.Option<TableNamesInConfectDataModel<ConfectDataModel>> {
+		return Array.findFirst(Record.keys(this.databaseSchemas), (tableName) =>
+			Option.isSome(this.normalizeId(tableName, id)),
+		);
+	}
+	normalizeId<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		id: string,
+	): Option.Option<GenericId<TableName>> {
+		return Option.fromNullable(this.db.normalizeId(tableName, id));
+	}
+	get<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+	): Effect.Effect<
+		Option.Option<ConfectDataModel[TableName]["confectDocument"]>
+	> {
+		return Effect.gen(this, function* () {
+			const optionConvexDoc = yield* Effect.promise(() => this.db.get(id)).pipe(
+				Effect.map(Option.fromNullable),
+			);
+			const tableName = yield* this.tableName(id).pipe(Effect.orDie);
+			return pipe(
+				optionConvexDoc,
+				Option.map((convexDoc) => this.decode(tableName, convexDoc)),
+			);
+		});
+	}
+	query<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+	): ConfectQueryInitializer<ConfectDataModel[TableName], TableName> {
+		return new ConfectQueryInitializerImpl(
+			this.db.query(tableName),
+			this.databaseSchemas[tableName],
+			tableName,
+		);
+	}
+}
+
+export class ConfectDatabaseReaderImpl<
+	ConfectDataModel extends GenericConfectDataModel,
+> implements ConfectDatabaseReader<ConfectDataModel>
+{
+	db: GenericDatabaseReader<DataModelFromConfectDataModel<ConfectDataModel>>;
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	system: ConfectBaseDatabaseReader<ConfectSystemDataModel>;
+	constructor(
+		db: GenericDatabaseReader<DataModelFromConfectDataModel<ConfectDataModel>>,
+		databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
+	) {
+		this.db = db;
+		this.databaseSchemas = databaseSchemas;
+		this.system = new ConfectBaseDatabaseReaderImpl<ConfectSystemDataModel>(
+			this.db.system,
+			databaseSchemasFromConfectSchema(
+				confectSystemSchemaDefinition.confectSchema,
+			),
+		);
+	}
+	decode<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		convexDocument: ConfectDataModel[TableName]["encodedConfectDocument"],
+	): ConfectDataModel[TableName]["confectDocument"] {
+		return decodeDocument(
+			tableName,
+			this.databaseSchemas[tableName],
+			convexDocument,
+		);
+	}
+	tableName(
+		id: GenericId<TableNamesInConfectDataModel<ConfectDataModel>>,
+	): Option.Option<TableNamesInConfectDataModel<ConfectDataModel>> {
+		return Array.findFirst(Record.keys(this.databaseSchemas), (tableName) =>
+			Option.isSome(this.normalizeId(tableName, id)),
+		);
+	}
+	normalizeId<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		id: string,
+	): Option.Option<GenericId<TableName>> {
+		return Option.fromNullable(this.db.normalizeId(tableName, id));
+	}
+	get<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+	): Effect.Effect<
+		Option.Option<ConfectDataModel[TableName]["confectDocument"]>
+	> {
+		return Effect.gen(this, function* () {
+			const optionConvexDoc = yield* Effect.promise(() => this.db.get(id)).pipe(
+				Effect.map(Option.fromNullable),
+			);
+			const tableName = yield* this.tableName(id).pipe(Effect.orDie);
+			return pipe(
+				optionConvexDoc,
+				Option.map((convexDoc) => this.decode(tableName, convexDoc)),
+			);
+		});
+	}
+	query<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+	): ConfectQueryInitializer<ConfectDataModel[TableName], TableName> {
+		return new ConfectQueryInitializerImpl(
+			this.db.query(tableName),
+			this.databaseSchemas[tableName],
+			tableName,
+		);
+	}
+}
+
+export interface ConfectDatabaseWriter<
+	ConfectDataModel extends GenericConfectDataModel,
+> {
+	query<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+	): ConfectQueryInitializer<ConfectDataModel[TableName], TableName>;
+	get<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+	): Effect.Effect<
+		Option.Option<ConfectDataModel[TableName]["confectDocument"]>
+	>;
+	normalizeId<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		id: string,
+	): Option.Option<GenericId<TableName>>;
+	insert<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		table: TableName,
+		value: WithoutSystemFields<
+			ConfectDocumentByName<ConfectDataModel, TableName>
+		>,
+	): Effect.Effect<GenericId<TableName>, ParseResult.ParseError>;
+	patch<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+		value: Partial<
+			WithoutSystemFields<ConfectDocumentByName<ConfectDataModel, TableName>>
+		>,
+	): Effect.Effect<void, ParseResult.ParseError | Cause.NoSuchElementException>;
+	replace<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+		value: WithOptionalSystemFields<
+			ConfectDocumentByName<ConfectDataModel, TableName>
+		>,
+	): Effect.Effect<void>;
+	delete(id: GenericId<string>): Effect.Effect<void>;
+}
+
+export class ConfectDatabaseWriterImpl<
+	ConfectDataModel extends GenericConfectDataModel,
+> implements ConfectDatabaseWriter<ConfectDataModel>
+{
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	db: GenericDatabaseWriter<DataModelFromConfectDataModel<ConfectDataModel>>;
+	reader: ConfectDatabaseReader<ConfectDataModel>;
+	constructor(
+		db: GenericDatabaseWriter<DataModelFromConfectDataModel<ConfectDataModel>>,
+		databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
+	) {
+		this.db = db;
+		this.databaseSchemas = databaseSchemas;
+		this.reader = new ConfectDatabaseReaderImpl(db, databaseSchemas);
+	}
+	tableName(
+		id: GenericId<TableNamesInConfectDataModel<ConfectDataModel>>,
+	): Option.Option<TableNamesInConfectDataModel<ConfectDataModel>> {
+		return Array.findFirst(Record.keys(this.databaseSchemas), (tableName) =>
+			Option.isSome(this.normalizeId(tableName, id)),
+		);
+	}
+	query<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+	): ConfectQueryInitializer<ConfectDataModel[TableName], TableName> {
+		return this.reader.query(tableName);
+	}
+	get<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+	): Effect.Effect<
+		Option.Option<ConfectDataModel[TableName]["confectDocument"]>
+	> {
+		return this.reader.get(id);
+	}
+	normalizeId<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		tableName: TableName,
+		id: string,
+	): Option.Option<GenericId<TableName>> {
+		return Option.fromNullable(this.db.normalizeId(tableName, id));
+	}
+	insert<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		table: TableName,
+		value: WithoutSystemFields<
+			ConfectDocumentByName<ConfectDataModel, TableName>
+		>,
+	): Effect.Effect<GenericId<TableName>, ParseResult.ParseError> {
+		return pipe(
+			value,
+			Schema.encode(this.databaseSchemas[table]),
+			Effect.andThen((encodedValue) =>
+				Effect.promise(() =>
+					this.db.insert(
+						table,
+						encodedValue as Expand<
+							BetterOmit<
+								DocumentByName<
+									DataModelFromConfectDataModel<ConfectDataModel>,
+									TableName
+								>,
+								"_creationTime" | "_id"
+							>
+						>,
+					),
+				),
+			),
+		);
+	}
+	patch<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+		value: Partial<
+			WithoutSystemFields<ConfectDocumentByName<ConfectDataModel, TableName>>
+		>,
+	): Effect.Effect<
+		void,
+		ParseResult.ParseError | Cause.NoSuchElementException
+	> {
+		return Effect.gen(this, function* () {
+			const tableName = yield* this.tableName(id);
+			const tableSchema = this.databaseSchemas[tableName];
+
+			const originalConvexDoc = yield* Effect.promise(() =>
+				this.db.get(id),
+			).pipe(
+				Effect.andThen(
+					(
+						doc: DocumentByName<
+							DataModelFromConfectDataModel<ConfectDataModel>,
+							TableName
+						> | null,
+					) =>
+						doc
+							? Effect.succeed(doc)
+							: Effect.die(new InvalidIdProvidedForPatch()),
+				),
+			);
+
+			const originalConfectDoc =
+				yield* Schema.decodeUnknown(tableSchema)(originalConvexDoc);
+
+			const updatedConvexDoc = yield* pipe(
+				value,
+				Record.reduce(originalConfectDoc, (acc, value, key) =>
+					value === undefined
+						? Record.remove(acc, key)
+						: Record.set(acc, key, value),
+				),
+				Schema.encodeUnknown(tableSchema),
+			);
+
+			yield* Effect.promise(() =>
+				this.db.replace(
+					id,
+					updatedConvexDoc as Expand<
+						BetterOmit<
+							DocumentByName<
+								DataModelFromConfectDataModel<ConfectDataModel>,
+								TableName
+							>,
+							"_creationTime" | "_id"
+						>
+					>,
+				),
+			);
+		});
+	}
+	replace<TableName extends TableNamesInConfectDataModel<ConfectDataModel>>(
+		id: GenericId<TableName>,
+		value: WithOptionalSystemFields<
+			ConfectDocumentByName<ConfectDataModel, TableName>
+		>,
+	): Effect.Effect<void> {
+		return Effect.promise(() => this.db.replace(id, value));
+	}
+	delete(id: GenericId<string>): Effect.Effect<void> {
+		return Effect.promise(() => this.db.delete(id));
+	}
+}
+
+export const databaseSchemasFromConfectSchema = <
+	ConfectSchema extends GenericConfectSchema,
+>(
+	confectSchema: ConfectSchema,
+) =>
+	Record.map(
+		confectSchema,
+		({ tableSchema }) => tableSchema,
+	) as DatabaseSchemasFromConfectDataModel<
+		ConfectDataModelFromConfectSchema<ConfectSchema>
+	>;
+
+class InvalidIdProvidedForPatch extends Data.TaggedError(
+	"InvalidIdProvidedForPatch",
+) {}
+
+const decodeDocument = <
+	TableName extends string,
+	ConvexDocument extends GenericEncodedConfectDocument,
+	ConfectDocument extends GenericConfectDocument,
+>(
+	tableName: TableName,
+	tableSchema: Schema.Schema<ConfectDocument, ConvexDocument>,
+	convexDocument: ConvexDocument,
+): ConfectDocument =>
+	Schema.decodeUnknownSync(extendWithSystemFields(tableName, tableSchema), {
+		onExcessProperty: "error",
+	})(convexDocument);
+
+// Would be better if this were exported from `convex/server`
+type BaseDatabaseReader<DataModel extends GenericDataModel> = Omit<
+	GenericDatabaseReader<DataModel>,
+	"system"
+>;

--- a/packages/confect/src/server/functions.ts
+++ b/packages/confect/src/server/functions.ts
@@ -1,0 +1,769 @@
+import {
+	actionGeneric,
+	type DefaultFunctionArgs,
+	type GenericActionCtx,
+	type GenericMutationCtx,
+	type GenericQueryCtx,
+	internalActionGeneric,
+	internalMutationGeneric,
+	internalQueryGeneric,
+	mutationGeneric,
+	queryGeneric,
+	type RegisteredAction,
+	type RegisteredMutation,
+	type RegisteredQuery,
+} from "convex/server";
+import { Effect, pipe, Schema } from "effect";
+
+import {
+	ConfectActionCtx,
+	ConfectMutationCtx,
+	ConfectQueryCtx,
+	makeConfectActionCtx,
+	makeConfectMutationCtx,
+	makeConfectQueryCtx,
+} from "./ctx";
+import type {
+	DataModelFromConfectDataModel,
+	GenericConfectDataModel,
+} from "./data-model";
+import {
+	type DatabaseSchemasFromConfectDataModel,
+	databaseSchemasFromConfectSchema,
+} from "./database";
+import type {
+	ConfectDataModelFromConfectSchema,
+	ConfectSchemaDefinition,
+	GenericConfectSchema,
+} from "./schema";
+import { compileArgsSchema, compileReturnsSchema } from "./schema-to-validator";
+
+type MutationBuilder = typeof mutationGeneric;
+type InternalMutationBuilder = typeof internalMutationGeneric;
+
+export interface MakeFunctionsOptions {
+	mutationBuilder?: MutationBuilder;
+	internalMutationBuilder?: InternalMutationBuilder;
+}
+
+export const makeFunctions = <ConfectSchema extends GenericConfectSchema>(
+	confectSchemaDefinition: ConfectSchemaDefinition<ConfectSchema>,
+	options?: MakeFunctionsOptions,
+) => {
+	const databaseSchemas = databaseSchemasFromConfectSchema(
+		confectSchemaDefinition.confectSchema,
+	);
+
+	const mutationBuilder = options?.mutationBuilder ?? mutationGeneric;
+	const internalMutationBuilder =
+		options?.internalMutationBuilder ?? internalMutationGeneric;
+
+	function query<
+		ConvexArgs extends DefaultFunctionArgs,
+		ConfectArgs,
+		ConvexReturns,
+		ConfectReturns,
+		E,
+	>({
+		args,
+		returns,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectArgs, ConvexArgs>;
+		returns: Schema.Schema<ConfectReturns, ConvexReturns>;
+		handler: (
+			a: ConfectArgs,
+		) => Effect.Effect<
+			ConfectReturns,
+			E,
+			ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredQuery<"public", ConvexArgs, Promise<ConvexReturns>>;
+	function query<
+		ConvexArgs extends DefaultFunctionArgs,
+		ConfectArgs,
+		ConvexSuccess,
+		ConfectSuccess,
+		ConvexError,
+		ConfectError extends { readonly _tag: string },
+	>({
+		args,
+		success,
+		error,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectArgs, ConvexArgs>;
+		success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+		error: Schema.Schema<ConfectError, ConvexError>;
+		handler: (
+			a: ConfectArgs,
+		) => Effect.Effect<
+			ConfectSuccess,
+			ConfectError,
+			ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredQuery<
+		"public",
+		ConvexArgs,
+		Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError>
+	>;
+	function query(opts: {
+		args: Schema.Schema<unknown, DefaultFunctionArgs>;
+		returns?: Schema.Schema<unknown, unknown>;
+		success?: Schema.Schema<unknown, unknown>;
+		error?: Schema.Schema<{ readonly _tag: string }, unknown>;
+		handler: (
+			a: unknown,
+		) => Effect.Effect<
+			unknown,
+			unknown,
+			ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}) {
+		if (opts.success && opts.error) {
+			return queryGeneric(
+				confectQueryFunctionWithResult({
+					databaseSchemas,
+					args: opts.args,
+					success: opts.success,
+					error: opts.error,
+					handler: opts.handler as (
+						a: unknown,
+					) => Effect.Effect<
+						unknown,
+						{ readonly _tag: string },
+						ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+					>,
+				}),
+			);
+		}
+		return queryGeneric(
+			confectQueryFunction({
+				databaseSchemas,
+				args: opts.args,
+				returns: opts.returns!,
+				handler: opts.handler,
+			}),
+		);
+	}
+
+	function internalQuery<
+		ConvexArgs extends DefaultFunctionArgs,
+		ConfectArgs,
+		ConvexReturns,
+		ConfectReturns,
+		E,
+	>({
+		args,
+		handler,
+		returns,
+	}: {
+		args: Schema.Schema<ConfectArgs, ConvexArgs>;
+		returns: Schema.Schema<ConfectReturns, ConvexReturns>;
+		handler: (
+			a: ConfectArgs,
+		) => Effect.Effect<
+			ConfectReturns,
+			E,
+			ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredQuery<"internal", ConvexArgs, Promise<ConvexReturns>>;
+	function internalQuery<
+		ConvexArgs extends DefaultFunctionArgs,
+		ConfectArgs,
+		ConvexSuccess,
+		ConfectSuccess,
+		ConvexError,
+		ConfectError extends { readonly _tag: string },
+	>({
+		args,
+		success,
+		error,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectArgs, ConvexArgs>;
+		success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+		error: Schema.Schema<ConfectError, ConvexError>;
+		handler: (
+			a: ConfectArgs,
+		) => Effect.Effect<
+			ConfectSuccess,
+			ConfectError,
+			ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredQuery<
+		"internal",
+		ConvexArgs,
+		Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError>
+	>;
+	function internalQuery(opts: {
+		args: Schema.Schema<unknown, DefaultFunctionArgs>;
+		returns?: Schema.Schema<unknown, unknown>;
+		success?: Schema.Schema<unknown, unknown>;
+		error?: Schema.Schema<{ readonly _tag: string }, unknown>;
+		handler: (
+			a: unknown,
+		) => Effect.Effect<
+			unknown,
+			unknown,
+			ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}) {
+		if (opts.success && opts.error) {
+			return internalQueryGeneric(
+				confectQueryFunctionWithResult({
+					databaseSchemas,
+					args: opts.args,
+					success: opts.success,
+					error: opts.error,
+					handler: opts.handler as (
+						a: unknown,
+					) => Effect.Effect<
+						unknown,
+						{ readonly _tag: string },
+						ConfectQueryCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+					>,
+				}),
+			);
+		}
+		return internalQueryGeneric(
+			confectQueryFunction({
+				databaseSchemas,
+				args: opts.args,
+				returns: opts.returns!,
+				handler: opts.handler,
+			}),
+		);
+	}
+
+	function mutation<
+		ConvexValue extends DefaultFunctionArgs,
+		ConfectValue,
+		ConvexReturns,
+		ConfectReturns,
+		E,
+	>({
+		args,
+		returns,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectValue, ConvexValue>;
+		returns: Schema.Schema<ConfectReturns, ConvexReturns>;
+		handler: (
+			a: ConfectValue,
+		) => Effect.Effect<
+			ConfectReturns,
+			E,
+			ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredMutation<"public", ConvexValue, Promise<ConvexReturns>>;
+	function mutation<
+		ConvexValue extends DefaultFunctionArgs,
+		ConfectValue,
+		ConvexSuccess,
+		ConfectSuccess,
+		ConvexError,
+		ConfectError extends { readonly _tag: string },
+	>({
+		args,
+		success,
+		error,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectValue, ConvexValue>;
+		success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+		error: Schema.Schema<ConfectError, ConvexError>;
+		handler: (
+			a: ConfectValue,
+		) => Effect.Effect<
+			ConfectSuccess,
+			ConfectError,
+			ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredMutation<
+		"public",
+		ConvexValue,
+		Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError>
+	>;
+	function mutation(opts: {
+		args: Schema.Schema<unknown, DefaultFunctionArgs>;
+		returns?: Schema.Schema<unknown, unknown>;
+		success?: Schema.Schema<unknown, unknown>;
+		error?: Schema.Schema<{ readonly _tag: string }, unknown>;
+		handler: (
+			a: unknown,
+		) => Effect.Effect<
+			unknown,
+			unknown,
+			ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}) {
+		if (opts.success && opts.error) {
+			return mutationBuilder(
+				confectMutationFunctionWithResult({
+					databaseSchemas,
+					args: opts.args,
+					success: opts.success,
+					error: opts.error,
+					handler: opts.handler as (
+						a: unknown,
+					) => Effect.Effect<
+						unknown,
+						{ readonly _tag: string },
+						ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+					>,
+				}),
+			);
+		}
+		return mutationBuilder(
+			confectMutationFunction({
+				databaseSchemas,
+				args: opts.args,
+				returns: opts.returns!,
+				handler: opts.handler,
+			}),
+		);
+	}
+
+	function internalMutation<
+		ConvexValue extends DefaultFunctionArgs,
+		ConfectValue,
+		ConvexReturns,
+		ConfectReturns,
+		E,
+	>({
+		args,
+		returns,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectValue, ConvexValue>;
+		returns: Schema.Schema<ConfectReturns, ConvexReturns>;
+		handler: (
+			a: ConfectValue,
+		) => Effect.Effect<
+			ConfectReturns,
+			E,
+			ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredMutation<"internal", ConvexValue, Promise<ConvexReturns>>;
+	function internalMutation<
+		ConvexValue extends DefaultFunctionArgs,
+		ConfectValue,
+		ConvexSuccess,
+		ConfectSuccess,
+		ConvexError,
+		ConfectError extends { readonly _tag: string },
+	>({
+		args,
+		success,
+		error,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectValue, ConvexValue>;
+		success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+		error: Schema.Schema<ConfectError, ConvexError>;
+		handler: (
+			a: ConfectValue,
+		) => Effect.Effect<
+			ConfectSuccess,
+			ConfectError,
+			ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredMutation<
+		"internal",
+		ConvexValue,
+		Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError>
+	>;
+	function internalMutation(opts: {
+		args: Schema.Schema<unknown, DefaultFunctionArgs>;
+		returns?: Schema.Schema<unknown, unknown>;
+		success?: Schema.Schema<unknown, unknown>;
+		error?: Schema.Schema<{ readonly _tag: string }, unknown>;
+		handler: (
+			a: unknown,
+		) => Effect.Effect<
+			unknown,
+			unknown,
+			ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}) {
+		if (opts.success && opts.error) {
+			return internalMutationBuilder(
+				confectMutationFunctionWithResult({
+					databaseSchemas,
+					args: opts.args,
+					success: opts.success,
+					error: opts.error,
+					handler: opts.handler as (
+						a: unknown,
+					) => Effect.Effect<
+						unknown,
+						{ readonly _tag: string },
+						ConfectMutationCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+					>,
+				}),
+			);
+		}
+		return internalMutationBuilder(
+			confectMutationFunction({
+				databaseSchemas,
+				args: opts.args,
+				returns: opts.returns!,
+				handler: opts.handler,
+			}),
+		);
+	}
+
+	const action = <
+		ConvexValue extends DefaultFunctionArgs,
+		ConfectValue,
+		ConvexSuccess,
+		ConfectSuccess,
+		ConvexError,
+		ConfectError extends { readonly _tag: string },
+	>({
+		args,
+		success,
+		error,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectValue, ConvexValue>;
+		success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+		error: Schema.Schema<ConfectError, ConvexError>;
+		handler: (
+			a: ConfectValue,
+		) => Effect.Effect<
+			ConfectSuccess,
+			ConfectError,
+			ConfectActionCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredAction<
+		"public",
+		ConvexValue,
+		Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError>
+	> => actionGeneric(confectActionFunction({ args, success, error, handler }));
+
+	const internalAction = <
+		ConvexValue extends DefaultFunctionArgs,
+		ConfectValue,
+		ConvexSuccess,
+		ConfectSuccess,
+		ConvexError,
+		ConfectError extends { readonly _tag: string },
+	>({
+		args,
+		success,
+		error,
+		handler,
+	}: {
+		args: Schema.Schema<ConfectValue, ConvexValue>;
+		success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+		error: Schema.Schema<ConfectError, ConvexError>;
+		handler: (
+			a: ConfectValue,
+		) => Effect.Effect<
+			ConfectSuccess,
+			ConfectError,
+			ConfectActionCtx<ConfectDataModelFromConfectSchema<ConfectSchema>>
+		>;
+	}): RegisteredAction<
+		"internal",
+		ConvexValue,
+		Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError>
+	> =>
+		internalActionGeneric(
+			confectActionFunction({ args, success, error, handler }),
+		);
+
+	return {
+		query,
+		internalQuery,
+		mutation,
+		internalMutation,
+		action,
+		internalAction,
+	};
+};
+
+const confectQueryFunction = <
+	ConfectDataModel extends GenericConfectDataModel,
+	ConvexArgs extends DefaultFunctionArgs,
+	ConfectArgs,
+	ConvexReturns,
+	ConfectReturns,
+	E,
+>({
+	databaseSchemas,
+	args,
+	returns,
+	handler,
+}: {
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	args: Schema.Schema<ConfectArgs, ConvexArgs>;
+	returns: Schema.Schema<ConfectReturns, ConvexReturns>;
+	handler: (
+		a: ConfectArgs,
+	) => Effect.Effect<ConfectReturns, E, ConfectQueryCtx<ConfectDataModel>>;
+}) => ({
+	args: compileArgsSchema(args),
+	returns: compileReturnsSchema(returns),
+	handler: (
+		ctx: GenericQueryCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+		actualArgs: ConvexArgs,
+	): Promise<ConvexReturns> =>
+		pipe(
+			actualArgs,
+			Schema.decode(args),
+			Effect.orDie,
+			Effect.andThen((decodedArgs) =>
+				handler(decodedArgs).pipe(
+					Effect.provideService(
+						ConfectQueryCtx<ConfectDataModel>(),
+						makeConfectQueryCtx(ctx, databaseSchemas),
+					),
+				),
+			),
+			Effect.andThen((convexReturns) =>
+				Schema.encodeUnknown(returns)(convexReturns),
+			),
+			Effect.runPromise,
+		),
+});
+
+const confectMutationFunction = <
+	ConfectDataModel extends GenericConfectDataModel,
+	ConvexValue extends DefaultFunctionArgs,
+	ConfectValue,
+	ConvexReturns,
+	ConfectReturns,
+	E,
+>({
+	databaseSchemas,
+	args,
+	returns,
+	handler,
+}: {
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	args: Schema.Schema<ConfectValue, ConvexValue>;
+	returns: Schema.Schema<ConfectReturns, ConvexReturns>;
+	handler: (
+		a: ConfectValue,
+	) => Effect.Effect<ConfectReturns, E, ConfectMutationCtx<ConfectDataModel>>;
+}) => ({
+	args: compileArgsSchema(args),
+	returns: compileReturnsSchema(returns),
+	handler: (
+		ctx: GenericMutationCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+		actualArgs: ConvexValue,
+	): Promise<ConvexReturns> =>
+		pipe(
+			actualArgs,
+			Schema.decode(args),
+			Effect.orDie,
+			Effect.andThen((decodedArgs) =>
+				handler(decodedArgs).pipe(
+					Effect.provideService(
+						ConfectMutationCtx<ConfectDataModel>(),
+						makeConfectMutationCtx(ctx, databaseSchemas),
+					),
+				),
+			),
+			Effect.andThen((convexReturns) =>
+				Schema.encodeUnknown(returns)(convexReturns),
+			),
+			Effect.runPromise,
+		),
+});
+
+const confectQueryFunctionWithResult = <
+	ConfectDataModel extends GenericConfectDataModel,
+	ConvexArgs extends DefaultFunctionArgs,
+	ConfectArgs,
+	ConvexSuccess,
+	ConfectSuccess,
+	ConvexError,
+	ConfectError extends { readonly _tag: string },
+>({
+	databaseSchemas,
+	args,
+	success,
+	error,
+	handler,
+}: {
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	args: Schema.Schema<ConfectArgs, ConvexArgs>;
+	success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+	error: Schema.Schema<ConfectError, ConvexError>;
+	handler: (
+		a: ConfectArgs,
+	) => Effect.Effect<
+		ConfectSuccess,
+		ConfectError,
+		ConfectQueryCtx<ConfectDataModel>
+	>;
+}) => {
+	const successSchema = Schema.Struct({
+		_tag: Schema.Literal("Success"),
+		data: success,
+	});
+	const resultSchema = Schema.Union(successSchema, error);
+
+	return {
+		args: compileArgsSchema(args),
+		returns: compileReturnsSchema(resultSchema),
+		handler: (
+			ctx: GenericQueryCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+			actualArgs: ConvexArgs,
+		): Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError> =>
+			pipe(
+				actualArgs,
+				Schema.decode(args),
+				Effect.orDie,
+				Effect.andThen((decodedArgs) =>
+					handler(decodedArgs).pipe(
+						Effect.provideService(
+							ConfectQueryCtx<ConfectDataModel>(),
+							makeConfectQueryCtx(ctx, databaseSchemas),
+						),
+					),
+				),
+				Effect.map(
+					(data): { _tag: "Success"; data: ConfectSuccess } | ConfectError => ({
+						_tag: "Success",
+						data,
+					}),
+				),
+				Effect.catchAll((e: ConfectError) => Effect.succeed(e)),
+				Effect.andThen((result) => Schema.encodeUnknown(resultSchema)(result)),
+				Effect.runPromise,
+			),
+	};
+};
+
+const confectMutationFunctionWithResult = <
+	ConfectDataModel extends GenericConfectDataModel,
+	ConvexValue extends DefaultFunctionArgs,
+	ConfectValue,
+	ConvexSuccess,
+	ConfectSuccess,
+	ConvexError,
+	ConfectError extends { readonly _tag: string },
+>({
+	databaseSchemas,
+	args,
+	success,
+	error,
+	handler,
+}: {
+	databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>;
+	args: Schema.Schema<ConfectValue, ConvexValue>;
+	success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+	error: Schema.Schema<ConfectError, ConvexError>;
+	handler: (
+		a: ConfectValue,
+	) => Effect.Effect<
+		ConfectSuccess,
+		ConfectError,
+		ConfectMutationCtx<ConfectDataModel>
+	>;
+}) => {
+	const successSchema = Schema.Struct({
+		_tag: Schema.Literal("Success"),
+		data: success,
+	});
+	const resultSchema = Schema.Union(successSchema, error);
+
+	return {
+		args: compileArgsSchema(args),
+		returns: compileReturnsSchema(resultSchema),
+		handler: (
+			ctx: GenericMutationCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+			actualArgs: ConvexValue,
+		): Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError> =>
+			pipe(
+				actualArgs,
+				Schema.decode(args),
+				Effect.orDie,
+				Effect.andThen((decodedArgs) =>
+					handler(decodedArgs).pipe(
+						Effect.provideService(
+							ConfectMutationCtx<ConfectDataModel>(),
+							makeConfectMutationCtx(ctx, databaseSchemas),
+						),
+					),
+				),
+				Effect.map(
+					(data): { _tag: "Success"; data: ConfectSuccess } | ConfectError => ({
+						_tag: "Success",
+						data,
+					}),
+				),
+				Effect.catchAll((e: ConfectError) => Effect.succeed(e)),
+				Effect.andThen((result) => Schema.encodeUnknown(resultSchema)(result)),
+				Effect.runPromise,
+			),
+	};
+};
+
+const confectActionFunction = <
+	ConfectDataModel extends GenericConfectDataModel,
+	ConvexValue extends DefaultFunctionArgs,
+	ConfectValue,
+	ConvexSuccess,
+	ConfectSuccess,
+	ConvexError,
+	ConfectError extends { readonly _tag: string },
+>({
+	args,
+	success,
+	error,
+	handler,
+}: {
+	args: Schema.Schema<ConfectValue, ConvexValue>;
+	success: Schema.Schema<ConfectSuccess, ConvexSuccess>;
+	error: Schema.Schema<ConfectError, ConvexError>;
+	handler: (
+		a: ConfectValue,
+	) => Effect.Effect<
+		ConfectSuccess,
+		ConfectError,
+		ConfectActionCtx<ConfectDataModel>
+	>;
+}) => {
+	const successSchema = Schema.Struct({
+		_tag: Schema.Literal("Success"),
+		data: success,
+	});
+	const resultSchema = Schema.Union(successSchema, error);
+
+	return {
+		args: compileArgsSchema(args),
+		returns: compileReturnsSchema(resultSchema),
+		handler: (
+			ctx: GenericActionCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+			actualArgs: ConvexValue,
+		): Promise<{ _tag: "Success"; data: ConvexSuccess } | ConvexError> =>
+			pipe(
+				actualArgs,
+				Schema.decode(args),
+				Effect.orDie,
+				Effect.andThen((decodedArgs) =>
+					handler(decodedArgs).pipe(
+						Effect.provideService(
+							ConfectActionCtx<ConfectDataModel>(),
+							makeConfectActionCtx(ctx),
+						),
+					),
+				),
+				Effect.map(
+					(data): { _tag: "Success"; data: ConfectSuccess } | ConfectError => ({
+						_tag: "Success",
+						data,
+					}),
+				),
+				Effect.catchAll((e: ConfectError) => Effect.succeed(e)),
+				Effect.andThen((result) => Schema.encodeUnknown(resultSchema)(result)),
+				Effect.runPromise,
+			),
+	};
+};

--- a/packages/confect/src/server/http.ts
+++ b/packages/confect/src/server/http.ts
@@ -1,0 +1,164 @@
+import {
+	type HttpApi as EffectHttpApi,
+	type HttpRouter as EffectHttpRouter,
+	HttpApiBuilder,
+	HttpApiScalar,
+	type HttpApp,
+	HttpServer,
+} from "@effect/platform";
+import {
+	type GenericActionCtx,
+	type HttpRouter,
+	httpActionGeneric,
+	httpRouter,
+	ROUTABLE_HTTP_METHODS,
+	type RouteSpecWithPathPrefix,
+} from "convex/server";
+import { Array, Layer, pipe, Record } from "effect";
+import { ConfectActionCtx, makeConfectActionCtx } from "./ctx";
+import type {
+	DataModelFromConfectDataModel,
+	GenericConfectDataModel,
+} from "./data-model";
+
+type Middleware = (
+	httpApp: HttpApp.Default,
+) => HttpApp.Default<
+	never,
+	| EffectHttpApi.Api
+	| HttpApiBuilder.Router
+	| EffectHttpRouter.HttpRouter.DefaultServices
+>;
+
+const makeHandler =
+	<ConfectDataModel extends GenericConfectDataModel>({
+		pathPrefix,
+		apiLive,
+		middleware,
+		scalar,
+	}: {
+		pathPrefix: RoutePath;
+		apiLive: Layer.Layer<EffectHttpApi.Api, never, ConfectActionCtx<any>>;
+		middleware?: Middleware;
+		scalar?: HttpApiScalar.ScalarConfig;
+	}) =>
+	(
+		ctx: GenericActionCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
+		request: Request,
+	): Promise<Response> => {
+		const ConfectActionCtxLive = Layer.succeed(
+			ConfectActionCtx<any>(),
+			makeConfectActionCtx(ctx),
+		);
+
+		const ApiLive = apiLive.pipe(Layer.provide(ConfectActionCtxLive));
+
+		const ApiDocsLive = HttpApiScalar.layer({
+			path: `${pathPrefix}docs`,
+			scalar: {
+				baseServerURL: `${
+					// biome-ignore lint/complexity/useLiteralKeys: TS says this must be accessed with a string literal
+					process.env["CONVEX_SITE_URL"]
+				}${pathPrefix}`,
+				...scalar,
+			},
+		}).pipe(Layer.provide(ApiLive));
+
+		const EnvLive = Layer.mergeAll(
+			ApiLive,
+			ApiDocsLive,
+			HttpServer.layerContext,
+		);
+
+		const { handler } = HttpApiBuilder.toWebHandler(EnvLive, { middleware });
+
+		return handler(request);
+	};
+
+const makeHttpAction = ({
+	pathPrefix,
+	apiLive,
+	middleware,
+	scalar,
+}: {
+	pathPrefix: RoutePath;
+	apiLive: Layer.Layer<EffectHttpApi.Api, never, ConfectActionCtx<any>>;
+	middleware?: Middleware;
+	scalar?: HttpApiScalar.ScalarConfig;
+}) =>
+	httpActionGeneric(makeHandler({ pathPrefix, apiLive, middleware, scalar }));
+
+export type HttpApi = {
+	apiLive: Layer.Layer<EffectHttpApi.Api, never, ConfectActionCtx<any>>;
+	middleware?: Middleware;
+	scalar?: HttpApiScalar.ScalarConfig;
+};
+
+export type RoutePath = "/" | `/${string}/`;
+
+const mountEffectHttpApi =
+	({
+		pathPrefix,
+		apiLive,
+		middleware,
+		scalar,
+	}: {
+		pathPrefix: RoutePath;
+		apiLive: Layer.Layer<EffectHttpApi.Api, never, ConfectActionCtx<any>>;
+		middleware?: Middleware;
+		scalar?: HttpApiScalar.ScalarConfig;
+	}) =>
+	(convexHttpRouter: HttpRouter): HttpRouter => {
+		const handler = makeHttpAction({ pathPrefix, apiLive, middleware, scalar });
+
+		Array.forEach(ROUTABLE_HTTP_METHODS, (method) => {
+			const routeSpec: RouteSpecWithPathPrefix = {
+				pathPrefix,
+				method,
+				handler,
+			};
+			convexHttpRouter.route(routeSpec);
+		});
+
+		return convexHttpRouter;
+	};
+
+type HttpApis = Partial<Record<RoutePath, HttpApi>>;
+
+const makeHttpRouter = (httpApis: HttpApis): HttpRouter => {
+	applyMonkeyPatches();
+
+	return pipe(
+		httpApis as Record<RoutePath, HttpApi>,
+		Record.toEntries,
+		Array.reduce(
+			httpRouter(),
+			(convexHttpRouter, [pathPrefix, { apiLive, middleware }]) =>
+				mountEffectHttpApi({
+					pathPrefix: pathPrefix as RoutePath,
+					apiLive,
+					middleware,
+				})(convexHttpRouter),
+		),
+	);
+};
+
+const applyMonkeyPatches = () => {
+	// These are necessary until the Convex runtime supports these APIs. See https://discord.com/channels/1019350475847499849/1281364098419785760
+
+	// biome-ignore lint/suspicious/noGlobalAssign: See above note.
+	URL = class extends URL {
+		override get username() {
+			return "";
+		}
+		override get password() {
+			return "";
+		}
+	};
+
+	Object.defineProperty(Request.prototype, "signal", {
+		get: () => new AbortSignal(),
+	});
+};
+
+export { makeHttpRouter };

--- a/packages/confect/src/server/index.ts
+++ b/packages/confect/src/server/index.ts
@@ -1,0 +1,27 @@
+export {
+	ConfectActionCtx,
+	ConfectMutationCtx,
+	ConfectQueryCtx,
+} from "./ctx";
+
+export type {
+	ConfectDoc,
+	TableNamesInConfectDataModel,
+} from "./data-model";
+
+export { NotUniqueError } from "./database";
+
+export { makeFunctions, type MakeFunctionsOptions } from "./functions";
+export {
+	type HttpApi,
+	makeHttpRouter,
+} from "./http";
+export {
+	type ConfectDataModelFromConfectSchemaDefinition,
+	defineSchema,
+	defineTable,
+} from "./schema";
+export { compileSchema } from "./schema-to-validator";
+export * as Id from "./schemas/Id";
+export * as PaginationOpts from "./schemas/PaginationOpts";
+export * as PaginationResult from "./schemas/PaginationResult";

--- a/packages/confect/src/server/scheduler.ts
+++ b/packages/confect/src/server/scheduler.ts
@@ -1,0 +1,42 @@
+import type {
+	OptionalRestArgs,
+	SchedulableFunctionReference,
+	Scheduler,
+} from "convex/server";
+import { Effect } from "effect";
+
+export interface ConfectScheduler {
+	runAfter<FuncRef extends SchedulableFunctionReference>(
+		delayMs: number,
+		functionReference: FuncRef,
+		...args: OptionalRestArgs<FuncRef>
+	): Effect.Effect<void>;
+	runAt<FuncRef extends SchedulableFunctionReference>(
+		timestamp: number | Date,
+		functionReference: FuncRef,
+		...args: OptionalRestArgs<FuncRef>
+	): Effect.Effect<void>;
+}
+
+export class ConfectSchedulerImpl implements ConfectScheduler {
+	constructor(private scheduler: Scheduler) {}
+
+	runAfter<FuncRef extends SchedulableFunctionReference>(
+		delayMs: number,
+		functionReference: FuncRef,
+		...args: OptionalRestArgs<FuncRef>
+	): Effect.Effect<void> {
+		return Effect.promise(() =>
+			this.scheduler.runAfter(delayMs, functionReference, ...args),
+		);
+	}
+	runAt<FuncRef extends SchedulableFunctionReference>(
+		timestamp: number | Date,
+		functionReference: FuncRef,
+		...args: OptionalRestArgs<FuncRef>
+	): Effect.Effect<void> {
+		return Effect.promise(() =>
+			this.scheduler.runAt(timestamp, functionReference, ...args),
+		);
+	}
+}

--- a/packages/confect/src/server/schema-to-validator.ts
+++ b/packages/confect/src/server/schema-to-validator.ts
@@ -1,0 +1,686 @@
+import type {
+	GenericId,
+	OptionalProperty,
+	PropertyValidators,
+	VAny,
+	VArray,
+	Validator,
+	VBoolean,
+	VBytes,
+	VFloat64,
+	VId,
+	VInt64,
+	VLiteral,
+	VNull,
+	VObject,
+	VOptional,
+	VString,
+	VUnion,
+} from "convex/values";
+import { v } from "convex/values";
+import {
+	Array,
+	Cause,
+	Data,
+	Effect,
+	Exit,
+	Match,
+	Number,
+	Option,
+	type ParseResult,
+	pipe,
+	Schema,
+	SchemaAST,
+	String,
+} from "effect";
+import { not } from "effect/Predicate";
+
+import * as Id from "./schemas/Id";
+import type {
+	DeepMutable,
+	IsAny,
+	IsOptional,
+	IsRecursive,
+	IsUnion,
+	IsValueLiteral,
+	TypeError,
+	UnionToTuple,
+} from "./type-utils";
+
+type JoinFieldPaths<
+	Prefix extends string,
+	Suffix extends string,
+> = Suffix extends "" ? Prefix : `${Prefix}.${Suffix}`;
+
+// Args
+
+export const compileArgsSchema = <ConfectValue, ConvexValue>(
+	argsSchema: Schema.Schema<ConfectValue, ConvexValue>,
+): PropertyValidators => {
+	const ast = Schema.encodedSchema(argsSchema).ast;
+
+	return pipe(
+		ast,
+		Match.value,
+		Match.tag("TypeLiteral", (typeLiteralAst) =>
+			Array.isEmptyReadonlyArray(typeLiteralAst.indexSignatures)
+				? handlePropertySignatures(typeLiteralAst)
+				: Effect.fail(new IndexSignaturesAreNotSupportedError()),
+		),
+		Match.orElse(() => Effect.fail(new TopLevelMustBeObjectError())),
+		runSyncThrow,
+	);
+};
+
+// Returns
+
+export const compileReturnsSchema = <ConfectValue, ConvexValue>(
+	schema: Schema.Schema<ConfectValue, ConvexValue>,
+): Validator<any, any, any> =>
+	runSyncThrow(compileAst(Schema.encodedSchema(schema).ast));
+
+// Table
+
+type SchemaEncodedFieldPaths<TableSchema extends Schema.Schema.AnyNoContext> =
+	TableSchema["Encoded"] extends infer E
+		? E extends ReadonlyRecordValue
+			? TopLevelFieldPaths<E>
+			: keyof TableSchema["Encoded"] & string
+		: keyof TableSchema["Encoded"] & string;
+
+/**
+ * Convert a table `Schema` to a table `Validator`.
+ * Falls back to a permissive VObject if the type is too complex.
+ */
+export type TableSchemaToTableValidator<
+	TableSchema extends Schema.Schema.AnyNoContext,
+> = ValueToValidator<TableSchema["Encoded"]> extends infer Vd
+	? Vd extends VObject<any, any, any, any> | VUnion<any, any, any, any>
+		? Vd
+		: VObject<
+				TableSchema["Encoded"],
+				Record<string, Validator<any, any, any>>,
+				"required",
+				SchemaEncodedFieldPaths<TableSchema>
+			>
+	: VObject<
+			TableSchema["Encoded"],
+			Record<string, Validator<any, any, any>>,
+			"required",
+			SchemaEncodedFieldPaths<TableSchema>
+		>;
+
+export const compileTableSchema = <
+	TableSchema extends Schema.Schema.AnyNoContext,
+>(
+	schema: TableSchema,
+): TableSchemaToTableValidator<TableSchema> => {
+	const ast = Schema.encodedSchema(schema).ast;
+
+	return pipe(
+		ast,
+		Match.value,
+		Match.tag("TypeLiteral", ({ indexSignatures }) =>
+			Array.isEmptyReadonlyArray(indexSignatures)
+				? (compileAst(ast) as Effect.Effect<any>)
+				: Effect.fail(new IndexSignaturesAreNotSupportedError()),
+		),
+		Match.tag("Union", (unionAst) => compileAst(unionAst)),
+		Match.orElse(() => Effect.fail(new TopLevelMustBeObjectOrUnionError())),
+		runSyncThrow,
+	);
+};
+
+// Compiler
+
+export type ReadonlyValue =
+	| string
+	| number
+	| bigint
+	| boolean
+	| ArrayBuffer
+	| ReadonlyArrayValue
+	| ReadonlyRecordValue
+	| null;
+
+type ReadonlyArrayValue = readonly ReadonlyValue[];
+
+export type ReadonlyRecordValue = {
+	readonly [key: string]: ReadonlyValue | undefined;
+};
+
+type MaxTypeDepth = 6;
+type IncrementDepth<N extends number> = [1, 2, 3, 4, 5, 6, 7][N];
+
+type CountKeys<T> = keyof T extends never
+	? 0
+	: keyof T extends string
+		? (keyof T)["length"] extends number
+			? 1
+			: 20
+		: 20;
+type IsTooComplex<T> = T extends ReadonlyRecordValue
+	? CountKeys<T> extends infer N extends number
+		? N extends 20
+			? true
+			: false
+		: false
+	: false;
+
+export type ValueToValidator<
+	Vl,
+	Depth extends number = 0,
+> = Depth extends MaxTypeDepth
+	? VAny
+	: IsRecursive<Vl> extends true
+		? VAny
+		: [Vl] extends [never]
+			? never
+			: IsAny<Vl> extends true
+				? VAny
+				: [Vl] extends [ReadonlyValue]
+					? Vl extends {
+							__tableName: infer TableName extends string;
+						}
+						? VId<GenericId<TableName>>
+						: IsValueLiteral<Vl> extends true
+							? VLiteral<Vl>
+							: Vl extends null
+								? VNull
+								: Vl extends number
+									? VFloat64
+									: Vl extends bigint
+										? VInt64
+										: Vl extends boolean
+											? VBoolean
+											: Vl extends string
+												? VString
+												: Vl extends ArrayBuffer
+													? VBytes
+													: Vl extends ReadonlyArray<ReadonlyValue>
+														? ArrayValueToValidator<Vl, Depth>
+														: Vl extends ReadonlyRecordValue
+															? RecordValueToValidator<Vl, Depth>
+															: IsUnion<Vl> extends true
+																? UnionValueToValidator<Vl, Depth>
+																: TypeError<"Unexpected value", Vl>
+					: TypeError<"Not a valid Convex value", Vl>;
+
+type ArrayValueToValidator<
+	Vl extends ReadonlyArray<ReadonlyValue>,
+	Depth extends number = 0,
+> = Depth extends MaxTypeDepth
+	? VArray<any, VAny>
+	: Vl extends ReadonlyArray<infer El extends ReadonlyValue>
+		? ValueToValidator<El, IncrementDepth<Depth>> extends infer Vd extends
+				Validator<any, any, any>
+			? VArray<DeepMutable<El[]>, Vd>
+			: VArray<any, VAny>
+		: VArray<any, VAny>;
+
+type ExtractFieldPathsFromValue<
+	Vl,
+	Prefix extends string = "",
+	Depth extends number = 0,
+> = Depth extends 4
+	? Prefix
+	: Vl extends ReadonlyRecordValue
+		? {
+				[K in keyof Vl & string]:
+					| JoinFieldPaths<Prefix, K>
+					| ExtractFieldPathsFromValue<
+							NonNullable<Vl[K]>,
+							JoinFieldPaths<Prefix, K>,
+							IncrementDepth<Depth>
+					  >;
+			}[keyof Vl & string]
+		: Prefix;
+
+type TopLevelFieldPaths<Vl extends ReadonlyRecordValue> = {
+	[K in keyof Vl & string]:
+		| K
+		| (NonNullable<Vl[K]> extends ReadonlyRecordValue
+				? `${K}.${keyof NonNullable<Vl[K]> & string}`
+				: never);
+}[keyof Vl & string];
+
+type RecordValueToValidator<
+	Vl,
+	Depth extends number = 0,
+> = Depth extends MaxTypeDepth
+	? VObject<any, any>
+	: Vl extends ReadonlyRecordValue
+		? RecordValueToValidatorInner<Vl, Depth>
+		: never;
+
+type SimpleFieldPaths<Vl extends ReadonlyRecordValue> = keyof Vl & string;
+
+type RecordValueToValidatorInner<
+	Vl extends ReadonlyRecordValue,
+	Depth extends number,
+> = {
+	-readonly [K in keyof Vl]-?: IsAny<Vl[K]> extends true
+		? IsOptional<Vl, K> extends true
+			? VOptional<VAny>
+			: VAny
+		: UndefinedOrValueToValidator<Vl[K], Depth>;
+} extends infer VdRecord extends Record<string, any>
+	? {
+			-readonly [K in keyof Vl]: DeepMutable<Vl[K]>;
+		} extends infer VlRecord extends Record<string, any>
+		? VObject<VlRecord, VdRecord, "required", SimpleFieldPaths<Vl>>
+		: VObject<any, any>
+	: VObject<any, any>;
+
+export type UndefinedOrValueToValidator<
+	Vl extends ReadonlyValue | undefined,
+	Depth extends number = 0,
+> = Depth extends MaxTypeDepth
+	? VOptional<VAny>
+	: undefined extends Vl
+		? Vl extends infer Val extends ReadonlyValue | undefined
+			? ValueToValidator<Val, IncrementDepth<Depth>> extends infer Vd extends
+					Validator<any, OptionalProperty, any>
+				? VOptional<Vd>
+				: VOptional<VAny>
+			: VOptional<VAny>
+		: Vl extends ReadonlyValue
+			? ValueToValidator<Vl, IncrementDepth<Depth>>
+			: VAny;
+
+type UnionValueToValidator<
+	Vl extends ReadonlyValue,
+	Depth extends number = 0,
+> = Depth extends MaxTypeDepth
+	? VAny
+	: [Vl] extends [ReadonlyValue]
+		? IsUnion<Vl> extends true
+			? UnionToTuple<Vl> extends infer VlTuple extends
+					ReadonlyArray<ReadonlyValue>
+				? ValueTupleToValidatorTuple<
+						VlTuple,
+						Depth
+					> extends infer VdTuple extends Validator<any, "required", any>[]
+					? VUnion<DeepMutable<Vl>, VdTuple>
+					: TypeError<"Failed to convert value tuple to validator tuple">
+				: TypeError<"Failed to convert union to tuple">
+			: TypeError<"Expected a union of values, but got a single value instead">
+		: TypeError<"Provided value is not a valid Convex value">;
+
+type ValueTupleToValidatorTuple<
+	VlTuple extends ReadonlyArray<ReadonlyValue>,
+	Depth extends number = 0,
+> = Depth extends MaxTypeDepth
+	? []
+	: VlTuple extends
+				| [true, false, ...infer VlRest extends ReadonlyArray<ReadonlyValue>]
+				| [false, true, ...infer VlRest extends ReadonlyArray<ReadonlyValue>]
+		? ValueTupleToValidatorTuple<
+				VlRest,
+				IncrementDepth<Depth>
+			> extends infer VdRest extends Validator<any, any, any>[]
+			? [VBoolean<boolean>, ...VdRest]
+			: never
+		: VlTuple extends [
+					infer Vl extends ReadonlyValue,
+					...infer VlRest extends ReadonlyArray<ReadonlyValue>,
+				]
+			? ValueToValidator<Vl, IncrementDepth<Depth>> extends infer Vd extends
+					Validator<any, any, any>
+				? ValueTupleToValidatorTuple<
+						VlRest,
+						IncrementDepth<Depth>
+					> extends infer VdRest extends Validator<any, "required", any>[]
+					? [Vd, ...VdRest]
+					: never
+				: never
+			: [];
+
+export const compileSchema = <T, E>(
+	schema: Schema.Schema<T, E>,
+): ValueToValidator<(typeof schema)["Encoded"]> =>
+	runSyncThrow(compileAst(schema.ast)) as any;
+
+export const isRecursive = (ast: SchemaAST.AST): boolean =>
+	pipe(
+		ast,
+		Match.value,
+		Match.tag(
+			"Literal",
+			"BooleanKeyword",
+			"StringKeyword",
+			"NumberKeyword",
+			"BigIntKeyword",
+			"UnknownKeyword",
+			"AnyKeyword",
+			"Declaration",
+			"UniqueSymbol",
+			"SymbolKeyword",
+			"UndefinedKeyword",
+			"VoidKeyword",
+			"NeverKeyword",
+			"Enums",
+			"TemplateLiteral",
+			"ObjectKeyword",
+			"Transformation",
+			() => false,
+		),
+		Match.tag("Union", ({ types }) =>
+			Array.some(types, (type) => isRecursive(type)),
+		),
+		Match.tag("TypeLiteral", ({ propertySignatures }) =>
+			Array.some(propertySignatures, ({ type }) => isRecursive(type)),
+		),
+		Match.tag(
+			"TupleType",
+			({ elements: optionalElements, rest: elements }) =>
+				Array.some(optionalElements, (optionalElement) =>
+					isRecursive(optionalElement.type),
+				) || Array.some(elements, (element) => isRecursive(element.type)),
+		),
+		Match.tag("Refinement", ({ from }) => isRecursive(from)),
+		Match.tag("Suspend", () => true),
+		Match.exhaustive,
+	);
+
+export const compileAst = (
+	ast: SchemaAST.AST,
+	isOptionalPropertyOfTypeLiteral = false,
+): Effect.Effect<
+	Validator<any, any, any>,
+	| UnsupportedSchemaTypeError
+	| UnsupportedPropertySignatureKeyTypeError
+	| IndexSignaturesAreNotSupportedError
+	| OptionalTupleElementsAreNotSupportedError
+	| EmptyTupleIsNotSupportedError
+> =>
+	isRecursive(ast)
+		? Effect.succeed(v.any())
+		: pipe(
+				ast,
+				Match.value,
+				Match.tag("Literal", ({ literal }) =>
+					pipe(
+						literal,
+						Match.value,
+						Match.whenOr(
+							Match.string,
+							Match.number,
+							Match.bigint,
+							Match.boolean,
+							(l) => v.literal(l),
+						),
+						Match.when(Match.null, () => v.null()),
+						Match.exhaustive,
+						Effect.succeed,
+					),
+				),
+				Match.tag("BooleanKeyword", () => Effect.succeed(v.boolean())),
+				Match.tag("StringKeyword", (stringAst) =>
+					Id.tableName(stringAst).pipe(
+						Option.match({
+							onNone: () => Effect.succeed(v.string()),
+							onSome: (tableName) => Effect.succeed(v.id(tableName)),
+						}),
+					),
+				),
+				Match.tag("NumberKeyword", () => Effect.succeed(v.float64())),
+				Match.tag("BigIntKeyword", () => Effect.succeed(v.int64())),
+				Match.tag("Union", (unionAst) =>
+					handleUnion(unionAst, isOptionalPropertyOfTypeLiteral),
+				),
+				Match.tag("TypeLiteral", (typeLiteralAst) =>
+					handleTypeLiteral(typeLiteralAst),
+				),
+				Match.tag("TupleType", (tupleTypeAst) => handleTupleType(tupleTypeAst)),
+				Match.tag("UnknownKeyword", "AnyKeyword", () =>
+					Effect.succeed(v.any()),
+				),
+				Match.tag("Declaration", (declaration) =>
+					Effect.mapBoth(
+						declaration.decodeUnknown(...declaration.typeParameters)(
+							new ArrayBuffer(0),
+							{},
+							declaration,
+						) as Effect.Effect<ArrayBuffer, ParseResult.ParseIssue>,
+						{
+							onSuccess: () => v.bytes(),
+							onFailure: () =>
+								new UnsupportedSchemaTypeError({
+									schemaType: declaration._tag,
+								}),
+						},
+					),
+				),
+				Match.tag("Refinement", ({ from }) => compileAst(from)),
+				/* v8 ignore next -- @preserve */
+				Match.tag("Suspend", () =>
+					Effect.dieMessage(
+						"Suspended schema should have already been handled by recursion check; this should be impossible.",
+					),
+				),
+				Match.tag(
+					"UniqueSymbol",
+					"SymbolKeyword",
+					"UndefinedKeyword",
+					"VoidKeyword",
+					"NeverKeyword",
+					"Enums",
+					"TemplateLiteral",
+					"ObjectKeyword",
+					"Transformation",
+					() =>
+						Effect.fail(
+							new UnsupportedSchemaTypeError({
+								schemaType: ast._tag,
+							}),
+						),
+				),
+				Match.exhaustive,
+			);
+
+const handleUnion = (
+	{ types: [first, second, ...rest] }: SchemaAST.Union,
+	isOptionalPropertyOfTypeLiteral: boolean,
+) =>
+	Effect.gen(function* () {
+		const validatorEffects = isOptionalPropertyOfTypeLiteral
+			? Array.filterMap([first, second, ...rest], (type) =>
+					not(SchemaAST.isUndefinedKeyword)(type)
+						? Option.some(compileAst(type))
+						: Option.none(),
+				)
+			: Array.map([first, second, ...rest], (type) => compileAst(type));
+
+		/* v8 ignore next -- @preserve */
+		const [firstValidator, secondValidator, ...restValidators] =
+			yield* Effect.all(validatorEffects);
+
+		/* v8 ignore if -- @preserve */
+		if (firstValidator === undefined) {
+			return yield* Effect.dieMessage(
+				"First validator of union is undefined; this should be impossible.",
+			);
+		} else if (secondValidator === undefined) {
+			return firstValidator;
+		} else {
+			return v.union(firstValidator, secondValidator, ...restValidators);
+		}
+	});
+
+const handleTypeLiteral = (typeLiteralAst: SchemaAST.TypeLiteral) =>
+	pipe(
+		typeLiteralAst.indexSignatures,
+		Array.head,
+		Option.match({
+			onNone: () =>
+				pipe(handlePropertySignatures(typeLiteralAst), Effect.map(v.object)),
+			/* v8 ignore next -- @preserve */
+			onSome: () => Effect.fail(new IndexSignaturesAreNotSupportedError()),
+		}),
+	);
+
+const handleTupleType = ({ elements, rest }: SchemaAST.TupleType) =>
+	Effect.gen(function* () {
+		const restValidator = pipe(
+			rest,
+			Array.head,
+			Option.map(({ type }) => compileAst(type)),
+			Effect.flatten,
+		);
+
+		const [f, s, ...r] = elements;
+
+		const elementToValidator = ({ type, isOptional }: SchemaAST.OptionalType) =>
+			Effect.if(isOptional, {
+				onTrue: () =>
+					Effect.fail(new OptionalTupleElementsAreNotSupportedError()),
+				onFalse: () => compileAst(type),
+			});
+
+		const arrayItemsValidator = yield* f === undefined
+			? pipe(
+					restValidator,
+					Effect.catchTag("NoSuchElementException", () =>
+						Effect.fail(new EmptyTupleIsNotSupportedError()),
+					),
+				)
+			: s === undefined
+				? elementToValidator(f)
+				: Effect.gen(function* () {
+						const firstValidator = yield* elementToValidator(f);
+						const secondValidator = yield* elementToValidator(s);
+						const restValidators = yield* Effect.forEach(r, elementToValidator);
+
+						return v.union(firstValidator, secondValidator, ...restValidators);
+					});
+
+		return v.array(arrayItemsValidator);
+	});
+
+const handlePropertySignatures = (typeLiteralAst: SchemaAST.TypeLiteral) =>
+	pipe(
+		typeLiteralAst.propertySignatures,
+		// biome-ignore lint/suspicious: False positive.
+		Effect.forEach(({ type, name, isOptional }) => {
+			if (String.isString(name)) {
+				// Somehow, somewhere, keys of type number are being coerced to strings…
+				return Option.match(Number.parse(name), {
+					onNone: () =>
+						Effect.gen(function* () {
+							const validator = yield* compileAst(type, isOptional);
+
+							return {
+								propertyName: name,
+								validator: isOptional ? v.optional(validator) : validator,
+							};
+						}),
+					onSome: (number) =>
+						Effect.fail(
+							new UnsupportedPropertySignatureKeyTypeError({
+								propertyKey: number,
+							}),
+						),
+				});
+			} else {
+				return Effect.fail(
+					new UnsupportedPropertySignatureKeyTypeError({ propertyKey: name }),
+				);
+			}
+		}),
+		Effect.andThen((propertyNamesWithValidators) =>
+			pipe(
+				propertyNamesWithValidators,
+				Array.reduce(
+					{} as Record<string, Validator<any, any, any>>,
+					(acc, { propertyName, validator }) => ({
+						[propertyName]: validator,
+						...acc,
+					}),
+				),
+				Effect.succeed,
+			),
+		),
+	);
+
+// Errors
+
+const runSyncThrow = <A, E>(effect: Effect.Effect<A, E>) =>
+	pipe(
+		effect,
+		Effect.runSyncExit,
+		Exit.match({
+			onSuccess: (validator) => validator,
+			onFailure: (cause) => {
+				throw Cause.squash(cause);
+			},
+		}),
+	);
+
+export class TopLevelMustBeObjectError extends Data.TaggedError(
+	"TopLevelMustBeObjectError",
+) {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return "Top level schema must be an object";
+	}
+}
+
+export class TopLevelMustBeObjectOrUnionError extends Data.TaggedError(
+	"TopLevelMustBeObjectOrUnionError",
+) {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return "Top level schema must be an object or a union";
+	}
+}
+
+export class UnsupportedPropertySignatureKeyTypeError extends Data.TaggedError(
+	"UnsupportedPropertySignatureKeyTypeError",
+)<{
+	readonly propertyKey: number | symbol;
+}> {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return `Unsupported property signature '${this.propertyKey.toString()}'. Property is of type '${typeof this
+			.propertyKey}' but only 'string' properties are supported.`;
+	}
+}
+
+export class EmptyTupleIsNotSupportedError extends Data.TaggedError(
+	"EmptyTupleIsNotSupportedError",
+) {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return "Tuple must have at least one element";
+	}
+}
+
+export class UnsupportedSchemaTypeError extends Data.TaggedError(
+	"UnsupportedSchemaTypeError",
+)<{
+	readonly schemaType: SchemaAST.AST["_tag"];
+}> {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return `Unsupported schema type '${this.schemaType}'`;
+	}
+}
+
+export class IndexSignaturesAreNotSupportedError extends Data.TaggedError(
+	"IndexSignaturesAreNotSupportedError",
+) {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return "Index signatures are not supported";
+	}
+}
+
+export class OptionalTupleElementsAreNotSupportedError extends Data.TaggedError(
+	"OptionalTupleElementsAreNotSupportedError",
+) {
+	/* v8 ignore next -- @preserve */
+	override get message() {
+		return "Optional tuple elements are not supported";
+	}
+}

--- a/packages/confect/src/server/schema.ts
+++ b/packages/confect/src/server/schema.ts
@@ -1,0 +1,520 @@
+import {
+	defineSchema as defineConvexSchema,
+	defineTable as defineConvexTable,
+	type Expand,
+	type GenericTableIndexes,
+	type GenericTableSearchIndexes,
+	type GenericTableVectorIndexes,
+	type IdField,
+	type IndexTiebreakerField,
+	type SchemaDefinition,
+	type SearchIndexConfig,
+	type SystemFields,
+	type SystemIndexes,
+	type TableDefinition,
+	type VectorIndexConfig,
+} from "convex/server";
+import type { Validator } from "convex/values";
+import { pipe, Record, Schema } from "effect";
+
+import {
+	compileTableSchema,
+	type TableSchemaToTableValidator,
+} from "./schema-to-validator";
+import {
+	type ExtendWithSystemFields,
+	extendWithSystemFields,
+} from "./schemas/SystemFields";
+import type { DeepMutable } from "./type-utils";
+
+export const confectTableSchemas = {
+	_scheduled_functions: Schema.Struct({
+		name: Schema.String,
+		args: Schema.Array(Schema.Any),
+		scheduledTime: Schema.Number,
+		completedTime: Schema.optional(Schema.Number),
+		state: Schema.Union(
+			Schema.Struct({ kind: Schema.Literal("pending") }),
+			Schema.Struct({ kind: Schema.Literal("inProgress") }),
+			Schema.Struct({ kind: Schema.Literal("success") }),
+			Schema.Struct({
+				kind: Schema.Literal("failed"),
+				error: Schema.String,
+			}),
+			Schema.Struct({ kind: Schema.Literal("canceled") }),
+		),
+	}),
+	_storage: Schema.Struct({
+		sha256: Schema.String,
+		size: Schema.Number,
+		contentType: Schema.optional(Schema.String),
+	}),
+};
+
+const tableSchemasFromConfectSchema = <
+	ConfectSchema extends GenericConfectSchema,
+>(
+	confectSchema: ConfectSchema,
+): TableSchemasFromConfectSchema<ConfectSchema> =>
+	({
+		...Record.map(confectSchema, ({ tableSchema }, tableName) => ({
+			withSystemFields: extendWithSystemFields(tableName, tableSchema),
+			withoutSystemFields: tableSchema,
+		})),
+		...Record.map(confectTableSchemas, (tableSchema, tableName) => ({
+			withSystemFields: extendWithSystemFields(tableName, tableSchema),
+			withoutSystemFields: tableSchema,
+		})),
+	}) as any;
+
+/**
+ * A Confect schema is a record of table definitions.
+ */
+export type GenericConfectSchema = Record<any, GenericConfectTableDefinition>;
+
+/**
+ * A Confect schema definition tracks the Confect schema, its Convex schema definition, and all of its table schemas.
+ */
+export type GenericConfectSchemaDefinition =
+	ConfectSchemaDefinition<GenericConfectSchema>;
+
+export interface ConfectSchemaDefinition<
+	ConfectSchema extends GenericConfectSchema,
+> {
+	confectSchema: ConfectSchema;
+	convexSchemaDefinition: SchemaDefinition<
+		SchemaDefinitionFromConfectSchemaDefinition<ConfectSchema>,
+		true
+	>;
+	tableSchemas: TableSchemasFromConfectSchema<ConfectSchema>;
+}
+
+class ConfectSchemaDefinitionImpl<ConfectSchema extends GenericConfectSchema>
+	implements ConfectSchemaDefinition<ConfectSchema>
+{
+	confectSchema: ConfectSchema;
+	convexSchemaDefinition: SchemaDefinition<
+		SchemaDefinitionFromConfectSchemaDefinition<ConfectSchema>,
+		true
+	>;
+	tableSchemas: TableSchemasFromConfectSchema<ConfectSchema>;
+
+	constructor(confectSchema: ConfectSchema) {
+		this.confectSchema = confectSchema;
+		this.convexSchemaDefinition = pipe(
+			confectSchema,
+			Record.map(({ tableDefinition }) => tableDefinition),
+			defineConvexSchema,
+		) as SchemaDefinition<
+			SchemaDefinitionFromConfectSchemaDefinition<ConfectSchema>,
+			true
+		>;
+		this.tableSchemas = tableSchemasFromConfectSchema(confectSchema);
+	}
+}
+
+type SchemaDefinitionFromConfectSchemaDefinition<
+	ConfectSchema extends GenericConfectSchema,
+> = Expand<{
+	[TableName in keyof ConfectSchema &
+		string]: ConfectSchema[TableName]["tableDefinition"];
+}>;
+
+/**
+ * Define a Confect schema.
+ */
+export const defineSchema = <ConfectSchema extends GenericConfectSchema>(
+	confectSchema: ConfectSchema,
+): ConfectSchemaDefinition<ConfectSchema> =>
+	new ConfectSchemaDefinitionImpl<ConfectSchema>(confectSchema);
+
+export type GenericConfectTableDefinition = ConfectTableDefinition<
+	any,
+	any,
+	any,
+	any,
+	any
+>;
+
+export interface ConfectTableDefinition<
+	TableSchema extends Schema.Schema.AnyNoContext,
+	TableValidator extends Validator<
+		any,
+		any,
+		any
+	> = TableSchemaToTableValidator<TableSchema>,
+	Indexes extends GenericTableIndexes = {},
+	SearchIndexes extends GenericTableSearchIndexes = {},
+	VectorIndexes extends GenericTableVectorIndexes = {},
+> {
+	tableDefinition: TableDefinition<
+		TableValidator,
+		Indexes,
+		SearchIndexes,
+		VectorIndexes
+	>;
+	tableSchema: TableSchema;
+
+	index<
+		IndexName extends string,
+		FirstFieldPath extends ExtractFieldPaths<TableValidator>,
+		RestFieldPaths extends ExtractFieldPaths<TableValidator>[],
+	>(
+		name: IndexName,
+		fields: [FirstFieldPath, ...RestFieldPaths],
+	): ConfectTableDefinition<
+		TableSchema,
+		TableValidator,
+		Expand<
+			Indexes &
+				Record<
+					IndexName,
+					[FirstFieldPath, ...RestFieldPaths, IndexTiebreakerField]
+				>
+		>,
+		SearchIndexes,
+		VectorIndexes
+	>;
+	searchIndex<
+		IndexName extends string,
+		SearchField extends ExtractFieldPaths<TableValidator>,
+		FilterFields extends ExtractFieldPaths<TableValidator> = never,
+	>(
+		name: IndexName,
+		indexConfig: Expand<SearchIndexConfig<SearchField, FilterFields>>,
+	): ConfectTableDefinition<
+		TableSchema,
+		TableValidator,
+		Indexes,
+		Expand<
+			SearchIndexes &
+				Record<
+					IndexName,
+					{
+						searchField: SearchField;
+						filterFields: FilterFields;
+					}
+				>
+		>,
+		VectorIndexes
+	>;
+	vectorIndex<
+		IndexName extends string,
+		VectorField extends ExtractFieldPaths<TableValidator>,
+		FilterFields extends ExtractFieldPaths<TableValidator> = never,
+	>(
+		name: IndexName,
+		indexConfig: Expand<VectorIndexConfig<VectorField, FilterFields>>,
+	): ConfectTableDefinition<
+		TableSchema,
+		TableValidator,
+		Indexes,
+		SearchIndexes,
+		Expand<
+			VectorIndexes &
+				Record<
+					IndexName,
+					{
+						vectorField: VectorField;
+						dimensions: number;
+						filterFields: FilterFields;
+					}
+				>
+		>
+	>;
+}
+
+export type ConfectSchemaFromConfectSchemaDefinition<
+	ConfectSchemaDef extends GenericConfectSchemaDefinition,
+> = ConfectSchemaDef extends ConfectSchemaDefinition<infer ConfectSchema>
+	? ConfectSchema
+	: never;
+
+/**
+ * @ignore
+ */
+export type ConfectDataModelFromConfectSchemaDefinition<
+	ConfectSchemaDef extends GenericConfectSchemaDefinition,
+> = ConfectSchemaDef extends ConfectSchemaDefinition<infer ConfectSchema>
+	? ConfectDataModelFromConfectSchema<ConfectSchema>
+	: never;
+
+class ConfectTableDefinitionImpl<
+	TableSchema extends Schema.Schema.AnyNoContext,
+	TableValidator extends Validator<
+		any,
+		any,
+		any
+	> = TableSchemaToTableValidator<TableSchema>,
+	Indexes extends GenericTableIndexes = {},
+	SearchIndexes extends GenericTableSearchIndexes = {},
+	VectorIndexes extends GenericTableVectorIndexes = {},
+> implements
+		ConfectTableDefinition<
+			TableSchema,
+			TableValidator,
+			Indexes,
+			SearchIndexes,
+			VectorIndexes
+		>
+{
+	tableSchema: TableSchema;
+	tableDefinition: TableDefinition<
+		TableValidator,
+		Indexes,
+		SearchIndexes,
+		VectorIndexes
+	>;
+
+	constructor(tableSchema: TableSchema, tableValidator: TableValidator) {
+		this.tableSchema = tableSchema;
+		this.tableDefinition = defineConvexTable(tableValidator);
+	}
+
+	index<
+		IndexName extends string,
+		FirstFieldPath extends ExtractFieldPaths<TableValidator>,
+		RestFieldPaths extends ExtractFieldPaths<TableValidator>[],
+	>(
+		name: IndexName,
+		fields: [FirstFieldPath, ...RestFieldPaths],
+	): ConfectTableDefinition<
+		TableSchema,
+		TableValidator,
+		Expand<
+			Indexes &
+				Record<
+					IndexName,
+					[FirstFieldPath, ...RestFieldPaths, IndexTiebreakerField]
+				>
+		>,
+		SearchIndexes,
+		VectorIndexes
+	> {
+		this.tableDefinition = this.tableDefinition.index(name, fields);
+
+		return this;
+	}
+
+	searchIndex<
+		IndexName extends string,
+		SearchField extends ExtractFieldPaths<TableValidator>,
+		FilterFields extends ExtractFieldPaths<TableValidator> = never,
+	>(
+		name: IndexName,
+		indexConfig: Expand<SearchIndexConfig<SearchField, FilterFields>>,
+	): ConfectTableDefinition<
+		TableSchema,
+		TableValidator,
+		Indexes,
+		Expand<
+			SearchIndexes &
+				Record<
+					IndexName,
+					{
+						searchField: SearchField;
+						filterFields: FilterFields;
+					}
+				>
+		>,
+		VectorIndexes
+	> {
+		this.tableDefinition = this.tableDefinition.searchIndex(name, indexConfig);
+
+		return this;
+	}
+
+	vectorIndex<
+		IndexName extends string,
+		VectorField extends ExtractFieldPaths<TableValidator>,
+		FilterFields extends ExtractFieldPaths<TableValidator> = never,
+	>(
+		name: IndexName,
+		indexConfig: {
+			vectorField: VectorField;
+			dimensions: number;
+			filterFields?: FilterFields[] | undefined;
+		},
+	): ConfectTableDefinition<
+		TableSchema,
+		TableValidator,
+		Indexes,
+		SearchIndexes,
+		Expand<
+			VectorIndexes &
+				Record<
+					IndexName,
+					{
+						vectorField: VectorField;
+						dimensions: number;
+						filterFields: FilterFields;
+					}
+				>
+		>
+	> {
+		this.tableDefinition = this.tableDefinition.vectorIndex(name, indexConfig);
+
+		return this;
+	}
+}
+
+/**
+ * Define a Confect table.
+ */
+export const defineTable = <TableSchema extends Schema.Schema.AnyNoContext>(
+	tableSchema: TableSchema,
+): ConfectTableDefinition<TableSchema> => {
+	const tableValidator = compileTableSchema(tableSchema);
+	return new ConfectTableDefinitionImpl(
+		tableSchema,
+		tableValidator,
+	) as ConfectTableDefinition<TableSchema>;
+};
+
+export type TableNamesInConfectSchema<
+	ConfectSchema extends GenericConfectSchema,
+> = keyof ConfectSchema & string;
+
+export type TableNamesInConfectSchemaDefinition<
+	ConfectSchemaDefinition extends GenericConfectSchemaDefinition,
+> = TableNamesInConfectSchema<ConfectSchemaDefinition["confectSchema"]>;
+
+/**
+ * Produce a Confect data model from a Confect schema.
+ */
+export type ConfectDataModelFromConfectSchema<
+	ConfectSchema extends GenericConfectSchema,
+> = {
+	[TableName in keyof ConfectSchema &
+		string]: ConfectSchema[TableName] extends ConfectTableDefinition<
+		infer TableSchema,
+		infer _TableValidator,
+		infer Indexes,
+		infer SearchIndexes,
+		infer VectorIndexes
+	>
+		? TableSchema extends Schema.Schema<any, any>
+			? {
+					confectDocument: ExtractConfectDocument<TableName, TableSchema>;
+					// It's pretty hard to recursively make an arbitrary TS type readonly/mutable, so we capture both the readonly version of the `convexDocument` (which is the `encodedConfectDocument`) and the mutable version (`convexDocument`).
+					encodedConfectDocument: ExtractEncodedConfectDocument<
+						TableName,
+						TableSchema
+					>;
+					convexDocument: ExtractMutableDocument<TableName, TableSchema>;
+					fieldPaths:
+						| keyof IdField<TableName>
+						| ExtractFieldPathsFromSchema<TableSchema>;
+					indexes: Expand<Indexes & SystemIndexes>;
+					searchIndexes: SearchIndexes;
+					vectorIndexes: VectorIndexes;
+				}
+			: never
+		: never;
+};
+
+type ExtractConfectDocument<
+	TableName extends string,
+	S extends Schema.Schema<any, any>,
+> = Expand<Readonly<IdField<TableName>> & Readonly<SystemFields> & S["Type"]>;
+
+type ExtractEncodedConfectDocument<
+	TableName extends string,
+	S extends Schema.Schema<any, any>,
+> = Expand<
+	Readonly<IdField<TableName>> & Readonly<SystemFields> & S["Encoded"]
+>;
+
+type ExtractMutableDocument<
+	TableName extends string,
+	S extends Schema.Schema<any, any>,
+> = Expand<IdField<TableName> & SystemFields & DeepMutable<S["Encoded"]>>;
+
+export const confectSystemSchema = {
+	_scheduled_functions: defineTable(confectTableSchemas._scheduled_functions),
+	_storage: defineTable(confectTableSchemas._storage),
+};
+
+export const confectSystemSchemaDefinition = defineSchema(confectSystemSchema);
+
+type ConfectSystemSchema = typeof confectSystemSchemaDefinition;
+
+export type ConfectSystemDataModel =
+	ConfectDataModelFromConfectSchemaDefinition<ConfectSystemSchema>;
+
+type TableSchemasFromConfectSchema<ConfectSchema extends GenericConfectSchema> =
+	Expand<
+		{
+			[TableName in keyof ConfectSchema & string]: {
+				withSystemFields: ExtendWithSystemFields<
+					TableName,
+					ConfectSchema[TableName]["tableSchema"]
+				>;
+				withoutSystemFields: ConfectSchema[TableName]["tableSchema"];
+			};
+		} & {
+			[TableName in keyof ConfectSystemSchema["confectSchema"]]: {
+				withSystemFields: ExtendWithSystemFields<
+					TableName,
+					ConfectSystemSchema["confectSchema"][TableName]["tableSchema"]
+				>;
+				withoutSystemFields: ConfectSystemSchema["confectSchema"][TableName]["tableSchema"];
+			};
+		}
+	>;
+
+// Vendored types from convex-js, partially modified. Ideally we could use these directly. See https://github.com/get-convex/convex-js/pull/14
+
+/**
+ * Extract field paths directly from a value type (Schema.Encoded).
+ * This is more robust than going through validator conversion.
+ */
+type ExtractFieldPathsFromEncodedValue<
+	T,
+	Prefix extends string = "",
+	Depth extends number = 0,
+> = Depth extends 3
+	? never
+	: T extends Record<string, unknown>
+		? {
+				[K in keyof T & string]:
+					| (Prefix extends "" ? K : `${Prefix}.${K}`)
+					| ExtractFieldPathsFromEncodedValue<
+							NonNullable<T[K]>,
+							Prefix extends "" ? K : `${Prefix}.${K}`,
+							[1, 2, 3, 4][Depth]
+					  >;
+			}[keyof T & string]
+		: never;
+
+/**
+ * Extract all of the index field paths within a {@link Validator}.
+ *
+ * This is used within {@link defineConvexTable}.
+ * @public
+ */
+type ExtractFieldPaths<T extends Validator<any, any, any>> =
+	// Add in the system fields available in index definitions.
+	// This should be everything except for `_id` because thats added to indexes
+	// automatically.
+	T["fieldPaths"] | keyof SystemFields;
+
+/**
+ * Extract field paths from a Schema, bypassing validator conversion.
+ * Use this when the schema is too complex for ValueToValidator.
+ */
+export type ExtractFieldPathsFromSchema<S extends Schema.Schema<any, any>> =
+	| ExtractFieldPathsFromEncodedValue<S["Encoded"]>
+	| keyof SystemFields;
+
+/**
+ * Extract the {@link GenericDocument} within a {@link Validator} and
+ * add on the system fields.
+ *
+ * This is used within {@link defineConvexTable}.
+ * @public
+ */
+type ExtractDocument<
+	TableName extends string,
+	T extends Validator<any, any, any>,
+> = Expand<IdField<TableName> & SystemFields & T["type"]>; //the table name) and trick TypeScript into expanding them. // Add the system fields to `Value` (except `_id` because it depends on

--- a/packages/confect/src/server/schemas/Id.ts
+++ b/packages/confect/src/server/schemas/Id.ts
@@ -1,0 +1,16 @@
+import type { GenericId } from "convex/values";
+import { type Option, Schema, SchemaAST } from "effect";
+
+const ConvexId = Symbol.for("ConvexId");
+
+export const Id = <TableName extends string>(
+	tableName: TableName,
+): Schema.Schema<GenericId<TableName>> =>
+	Schema.String.pipe(
+		Schema.annotations({ [ConvexId]: tableName }),
+	) as unknown as Schema.Schema<GenericId<TableName>>;
+
+export const tableName = <TableName extends string>(
+	ast: SchemaAST.AST,
+): Option.Option<TableName> =>
+	SchemaAST.getAnnotation<TableName>(ConvexId)(ast);

--- a/packages/confect/src/server/schemas/PaginationOpts.ts
+++ b/packages/confect/src/server/schemas/PaginationOpts.ts
@@ -1,0 +1,6 @@
+import { Schema } from "effect";
+
+export const PaginationOpts = Schema.Struct({
+	numItems: Schema.Number,
+	cursor: Schema.NullOr(Schema.String),
+});

--- a/packages/confect/src/server/schemas/PaginationResult.ts
+++ b/packages/confect/src/server/schemas/PaginationResult.ts
@@ -1,0 +1,18 @@
+import { Schema } from "effect";
+
+export const PaginationResult = <Doc extends Schema.Schema.AnyNoContext>(
+	Doc: Doc,
+) =>
+	Schema.Struct({
+		page: Schema.Array(Doc).pipe(Schema.mutable),
+		isDone: Schema.Boolean,
+		continueCursor: Schema.String,
+		splitCursor: Schema.optional(Schema.Union(Schema.String, Schema.Null)),
+		pageStatus: Schema.optional(
+			Schema.Union(
+				Schema.Literal("SplitRecommended"),
+				Schema.Literal("SplitRequired"),
+				Schema.Null,
+			),
+		),
+	}).pipe(Schema.mutable);

--- a/packages/confect/src/server/schemas/SystemFields.ts
+++ b/packages/confect/src/server/schemas/SystemFields.ts
@@ -1,0 +1,31 @@
+import { Schema } from "effect";
+import { Id } from "../schemas/Id";
+
+/**
+ * Produces a schema for Convex system fields.
+ */
+export const SystemFields = <TableName extends string>(tableName: TableName) =>
+	Schema.Struct({
+		_id: Id(tableName),
+		_creationTime: Schema.Number,
+	});
+
+/**
+ * Extend a table schema with Convex system fields.
+ */
+export const extendWithSystemFields = <
+	TableName extends string,
+	TableSchema extends Schema.Schema.AnyNoContext,
+>(
+	tableName: TableName,
+	schema: TableSchema,
+): ExtendWithSystemFields<TableName, TableSchema> =>
+	Schema.extend(schema, SystemFields(tableName));
+
+/**
+ * Extend a table schema with Convex system fields at the type level.
+ */
+export type ExtendWithSystemFields<
+	TableName extends string,
+	TableSchema extends Schema.Schema.AnyNoContext,
+> = Schema.extend<TableSchema, ReturnType<typeof SystemFields<TableName>>>;

--- a/packages/confect/src/server/storage.ts
+++ b/packages/confect/src/server/storage.ts
@@ -1,0 +1,43 @@
+import type { StorageReader, StorageWriter } from "convex/server";
+import type { GenericId } from "convex/values";
+import { Effect, Option } from "effect";
+
+export interface ConfectStorageReader {
+	getUrl(
+		storageId: GenericId<"_storage">,
+	): Effect.Effect<Option.Option<string>>;
+}
+
+export class ConfectStorageReaderImpl implements ConfectStorageReader {
+	constructor(private storageReader: StorageReader) {}
+	getUrl(
+		storageId: GenericId<"_storage">,
+	): Effect.Effect<Option.Option<string>> {
+		return Effect.promise(() => this.storageReader.getUrl(storageId)).pipe(
+			Effect.map(Option.fromNullable),
+		);
+	}
+}
+
+export interface ConfectStorageWriter extends ConfectStorageReader {
+	generateUploadUrl(): Effect.Effect<string>;
+	delete(storageId: GenericId<"_storage">): Effect.Effect<void>;
+}
+
+export class ConfectStorageWriterImpl implements ConfectStorageWriter {
+	private confectStorageReader: ConfectStorageReader;
+	constructor(private storageWriter: StorageWriter) {
+		this.confectStorageReader = new ConfectStorageReaderImpl(storageWriter);
+	}
+	getUrl(
+		storageId: GenericId<"_storage">,
+	): Effect.Effect<Option.Option<string>> {
+		return this.confectStorageReader.getUrl(storageId);
+	}
+	generateUploadUrl(): Effect.Effect<string> {
+		return Effect.promise(() => this.storageWriter.generateUploadUrl());
+	}
+	delete(storageId: GenericId<"_storage">): Effect.Effect<void> {
+		return Effect.promise(() => this.storageWriter.delete(storageId));
+	}
+}

--- a/packages/confect/src/server/type-utils.d.ts
+++ b/packages/confect/src/server/type-utils.d.ts
@@ -1,0 +1,127 @@
+import type { GenericId } from "convex/values";
+import type { Brand } from "effect";
+
+export type IsOptional<T, K extends keyof T> = {} extends Pick<T, K>
+	? true
+	: false;
+
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+
+export type IsUnion<T, U extends T = T> = T extends unknown
+	? [U] extends [T]
+		? false
+		: true
+	: never;
+
+// https://stackoverflow.com/a/52806744
+export type IsValueLiteral<Vl> = [Vl] extends [never]
+	? never
+	: [Vl] extends [string | number | bigint | boolean]
+		? [string] extends [Vl]
+			? false
+			: [number] extends [Vl]
+				? false
+				: [boolean] extends [Vl]
+					? false
+					: [bigint] extends [Vl]
+						? false
+						: true
+		: false;
+
+export type DeepMutable<T> = IsAny<T> extends true
+	? any
+	: T extends Brand.Brand<any> | GenericId<any>
+		? T
+		: T extends ReadonlyArray<infer U>
+			? DeepMutable<U>[]
+			: T extends ReadonlyMap<infer K, infer V>
+				? Map<DeepMutable<K>, DeepMutable<V>>
+				: T extends ReadonlySet<infer V>
+					? Set<DeepMutable<V>>
+					: [keyof T] extends [never]
+						? T
+						: { -readonly [K in keyof T]: DeepMutable<T[K]> };
+
+export type DeepReadonly<T> = IsAny<T> extends true
+	? any
+	: T extends Map<infer K, infer V>
+		? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
+		: T extends Set<infer V>
+			? ReadonlySet<DeepReadonly<V>>
+			: [keyof T] extends [never]
+				? T
+				: { readonly [K in keyof T]: DeepReadonly<T[K]> };
+
+export type TypeError<Message extends string, T = never> = [Message, T];
+
+export type IsRecursive<T> = true extends DetectCycle<T, [], 0> ? true : false;
+
+type MaxDepth = 10;
+type Increment<N extends number> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11][N];
+
+type DetectCycle<
+	T,
+	Cache extends any[] = [],
+	Depth extends number = 0,
+> = Depth extends MaxDepth
+	? false
+	: IsAny<T> extends true
+		? false
+		: [T] extends [any]
+			? T extends Cache[number]
+				? true
+				: T extends Array<infer U>
+					? DetectCycle<U, [...Cache, T], Increment<Depth>>
+					: T extends Map<infer _U, infer V>
+						? DetectCycle<V, [...Cache, T], Increment<Depth>>
+						: T extends Set<infer U>
+							? DetectCycle<U, [...Cache, T], Increment<Depth>>
+							: T extends object
+								? true extends {
+										[K in keyof T]: DetectCycle<
+											T[K],
+											[...Cache, T],
+											Increment<Depth>
+										>;
+									}[keyof T]
+									? true
+									: false
+								: false
+			: never;
+
+//////////////////////////////////
+// START: Vendored from Arktype //
+//////////////////////////////////
+
+// https://github.com/arktypeio/arktype/blob/2e911d01a741ccee7a17e31ee144049817fabbb8/ark/util/unionToTuple.ts#L9
+
+export type UnionToTuple<t> = _unionToTuple<t, []> extends infer result
+	? conform<result, t[]>
+	: never;
+
+type _unionToTuple<
+	t,
+	result extends unknown[],
+> = getLastBranch<t> extends infer current
+	? [t] extends [never]
+		? result
+		: _unionToTuple<Exclude<t, current>, [current, ...result]>
+	: never;
+
+type getLastBranch<t> = intersectUnion<
+	t extends unknown ? (x: t) => void : never
+> extends (x: infer branch) => void
+	? branch
+	: never;
+
+type intersectUnion<t> = (t extends unknown ? (_: t) => void : never) extends (
+	_: infer intersection,
+) => void
+	? intersection
+	: never;
+
+type conform<t, base> = t extends base ? t : base;
+
+////////////////////////////////
+// END: Vendored from Arktype //
+////////////////////////////////

--- a/packages/confect/tsconfig.json
+++ b/packages/confect/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"lib": ["ES2022", "dom"],
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"isolatedModules": true,
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Vendors the `@rjdellecese/confect` package with custom mutation builder support for trigger integration
- Provides Effect-based wrappers for Convex functions with type-safe schemas

## Stack

This is part 1 of a stacked diff series to migrate to confect:

1. **This PR** - Vendor confect package
2. Add github-api package
3. Add confect schemas and setup in database
4. Migrate rate limiter functions
5. Migrate stripe functions  
6. Migrate github functions
7. Migrate server_preferences functions
8. Migrate admin functions