### PR TITLE
feat: add @packages/github-api package

### DIFF
--- a/packages/github-api/open-api.json
+++ b/packages/github-api/open-api.json
@@ -1,0 +1,2787 @@
+{
+	"openapi": "3.0.3",
+	"info": {
+		"title": "GitHub REST API (Minimal)",
+		"description": "Minimal subset of GitHub REST API for AnswerOverflow",
+		"version": "1.1.4"
+	},
+	"servers": [
+		{
+			"url": "https://api.github.com"
+		}
+	],
+	"paths": {
+		"/user/installations": {
+			"get": {
+				"summary": "List app installations accessible to the user access token",
+				"description": "Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou can find the permissions for the installation under the `permissions` key.",
+				"tags": ["apps"],
+				"operationId": "apps/list-installations-for-authenticated-user",
+				"externalDocs": {
+					"description": "API method documentation",
+					"url": "https://docs.github.com/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"
+				},
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/per-page"
+					},
+					{
+						"$ref": "#/components/parameters/page"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "You can find the permissions for the installation under the `permissions` key.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"required": ["total_count", "installations"],
+									"properties": {
+										"total_count": {
+											"type": "integer"
+										},
+										"installations": {
+											"type": "array",
+											"items": {
+												"$ref": "#/components/schemas/installation"
+											}
+										}
+									}
+								},
+								"examples": {
+									"default": {
+										"$ref": "#/components/examples/base-installation-for-auth-user-paginated"
+									}
+								}
+							}
+						},
+						"headers": {
+							"Link": {
+								"$ref": "#/components/headers/link"
+							}
+						}
+					},
+					"304": {
+						"$ref": "#/components/responses/not_modified"
+					},
+					"401": {
+						"$ref": "#/components/responses/requires_authentication"
+					},
+					"403": {
+						"$ref": "#/components/responses/forbidden"
+					}
+				},
+				"x-github": {
+					"githubCloudOnly": false,
+					"enabledForGitHubApps": false,
+					"category": "apps",
+					"subcategory": "installations"
+				}
+			}
+		},
+		"/user/installations/{installation_id}/repositories": {
+			"get": {
+				"summary": "List repositories accessible to the user access token",
+				"description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+				"tags": ["apps"],
+				"operationId": "apps/list-installation-repos-for-authenticated-user",
+				"externalDocs": {
+					"description": "API method documentation",
+					"url": "https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-user-access-token"
+				},
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/installation-id"
+					},
+					{
+						"$ref": "#/components/parameters/per-page"
+					},
+					{
+						"$ref": "#/components/parameters/page"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "The access the user has to each repository is included in the hash under the `permissions` key.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"required": ["total_count", "repositories"],
+									"properties": {
+										"total_count": {
+											"type": "integer"
+										},
+										"repository_selection": {
+											"type": "string"
+										},
+										"repositories": {
+											"type": "array",
+											"items": {
+												"$ref": "#/components/schemas/repository"
+											}
+										}
+									}
+								},
+								"examples": {
+									"default": {
+										"$ref": "#/components/examples/repository-paginated"
+									}
+								}
+							}
+						},
+						"headers": {
+							"Link": {
+								"$ref": "#/components/headers/link"
+							}
+						}
+					},
+					"304": {
+						"$ref": "#/components/responses/not_modified"
+					},
+					"403": {
+						"$ref": "#/components/responses/forbidden"
+					},
+					"404": {
+						"$ref": "#/components/responses/not_found"
+					}
+				},
+				"x-github": {
+					"githubCloudOnly": false,
+					"enabledForGitHubApps": false,
+					"category": "apps",
+					"subcategory": "installations"
+				}
+			}
+		},
+		"/repos/{owner}/{repo}/issues": {
+			"get": {
+				"summary": "List repository issues",
+				"description": "List issues in a repository. Only open issues will be listed.\n\n> [!NOTE]\n> GitHub's REST API considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key. Be aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://docs.github.com/rest/pulls/pulls#list-pull-requests)\" endpoint.\n\nThis endpoint supports the following custom media types. For more information, see \"[Media types](https://docs.github.com/rest/using-the-rest-api/getting-started-with-the-rest-api#media-types).\"\n\n- **`application/vnd.github.raw+json`**: Returns the raw markdown body. Response will include `body`. This is the default if you do not pass any specific media type.\n- **`application/vnd.github.text+json`**: Returns a text only representation of the markdown body. Response will include `body_text`.\n- **`application/vnd.github.html+json`**: Returns HTML rendered from the body's markdown. Response will include `body_html`.\n- **`application/vnd.github.full+json`**: Returns raw, text, and HTML representations. Response will include `body`, `body_text`, and `body_html`.",
+				"tags": ["issues"],
+				"operationId": "issues/list-for-repo",
+				"externalDocs": {
+					"description": "API method documentation",
+					"url": "https://docs.github.com/rest/issues/issues#list-repository-issues"
+				},
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/owner"
+					},
+					{
+						"$ref": "#/components/parameters/repo"
+					},
+					{
+						"name": "milestone",
+						"description": "If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "state",
+						"description": "Indicates the state of the issues to return.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string",
+							"enum": ["open", "closed", "all"],
+							"default": "open"
+						}
+					},
+					{
+						"name": "assignee",
+						"description": "Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "type",
+						"description": "Can be the name of an issue type. If the string `*` is passed, issues with any type are accepted. If the string `none` is passed, issues without type are returned.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "creator",
+						"description": "The user that created the issue.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "mentioned",
+						"description": "A user that's mentioned in the issue.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"$ref": "#/components/parameters/labels"
+					},
+					{
+						"name": "sort",
+						"description": "What to sort results by.",
+						"in": "query",
+						"required": false,
+						"schema": {
+							"type": "string",
+							"enum": ["created", "updated", "comments"],
+							"default": "created"
+						}
+					},
+					{
+						"$ref": "#/components/parameters/direction"
+					},
+					{
+						"$ref": "#/components/parameters/since"
+					},
+					{
+						"$ref": "#/components/parameters/per-page"
+					},
+					{
+						"$ref": "#/components/parameters/page"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/issue"
+									}
+								},
+								"examples": {
+									"default": {
+										"$ref": "#/components/examples/issue-items"
+									}
+								}
+							}
+						},
+						"headers": {
+							"Link": {
+								"$ref": "#/components/headers/link"
+							}
+						}
+					},
+					"301": {
+						"$ref": "#/components/responses/moved_permanently"
+					},
+					"404": {
+						"$ref": "#/components/responses/not_found"
+					},
+					"422": {
+						"$ref": "#/components/responses/validation_failed"
+					}
+				},
+				"x-github": {
+					"githubCloudOnly": false,
+					"enabledForGitHubApps": true,
+					"category": "issues",
+					"subcategory": "issues"
+				}
+			},
+			"post": {
+				"summary": "Create an issue",
+				"description": "Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://docs.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.\n\nThis endpoint triggers [notifications](https://docs.github.com/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in secondary rate limiting. For more information, see \"[Rate limits for the API](https://docs.github.com/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits)\"\nand \"[Best practices for using the REST API](https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api).\"\n\nThis endpoint supports the following custom media types. For more information, see \"[Media types](https://docs.github.com/rest/using-the-rest-api/getting-started-with-the-rest-api#media-types).\"\n\n- **`application/vnd.github.raw+json`**: Returns the raw markdown body. Response will include `body`. This is the default if you do not pass any specific media type.\n- **`application/vnd.github.text+json`**: Returns a text only representation of the markdown body. Response will include `body_text`.\n- **`application/vnd.github.html+json`**: Returns HTML rendered from the body's markdown. Response will include `body_html`.\n- **`application/vnd.github.full+json`**: Returns raw, text, and HTML representations. Response will include `body`, `body_text`, and `body_html`.",
+				"tags": ["issues"],
+				"operationId": "issues/create",
+				"externalDocs": {
+					"description": "API method documentation",
+					"url": "https://docs.github.com/rest/issues/issues#create-an-issue"
+				},
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/owner"
+					},
+					{
+						"$ref": "#/components/parameters/repo"
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"title": {
+										"oneOf": [
+											{
+												"type": "string"
+											},
+											{
+												"type": "integer"
+											}
+										],
+										"description": "The title of the issue."
+									},
+									"body": {
+										"type": "string",
+										"description": "The contents of the issue."
+									},
+									"assignee": {
+										"type": "string",
+										"description": "Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is closing down.**_",
+										"nullable": true
+									},
+									"milestone": {
+										"oneOf": [
+											{
+												"type": "string"
+											},
+											{
+												"type": "integer",
+												"description": "The `number` of the milestone to associate this issue with. _NOTE: Only users with push access can set the milestone for new issues. The milestone is silently dropped otherwise._"
+											}
+										],
+										"nullable": true
+									},
+									"labels": {
+										"type": "array",
+										"description": "Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._",
+										"items": {
+											"oneOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "object",
+													"properties": {
+														"id": {
+															"type": "integer"
+														},
+														"name": {
+															"type": "string"
+														},
+														"description": {
+															"type": "string",
+															"nullable": true
+														},
+														"color": {
+															"type": "string",
+															"nullable": true
+														}
+													}
+												}
+											]
+										}
+									},
+									"assignees": {
+										"type": "array",
+										"description": "Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._",
+										"items": {
+											"type": "string"
+										}
+									},
+									"type": {
+										"type": "string",
+										"description": "The name of the issue type to associate with this issue. _NOTE: Only users with push access can set the type for new issues. The type is silently dropped otherwise._",
+										"nullable": true,
+										"example": "Epic"
+									}
+								},
+								"required": ["title"]
+							},
+							"examples": {
+								"default": {
+									"value": {
+										"title": "Found a bug",
+										"body": "I'm having a problem with this.",
+										"assignees": ["octocat"],
+										"milestone": 1,
+										"labels": ["bug"]
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"201": {
+						"description": "Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/issue"
+								},
+								"examples": {
+									"default": {
+										"$ref": "#/components/examples/issue"
+									}
+								}
+							}
+						},
+						"headers": {
+							"Location": {
+								"example": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/bad_request"
+					},
+					"403": {
+						"$ref": "#/components/responses/forbidden"
+					},
+					"404": {
+						"$ref": "#/components/responses/not_found"
+					},
+					"410": {
+						"$ref": "#/components/responses/gone"
+					},
+					"422": {
+						"$ref": "#/components/responses/validation_failed"
+					},
+					"503": {
+						"$ref": "#/components/responses/service_unavailable"
+					}
+				},
+				"x-github": {
+					"triggersNotification": true,
+					"githubCloudOnly": false,
+					"enabledForGitHubApps": true,
+					"category": "issues",
+					"subcategory": "issues"
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"installation": {
+				"title": "Installation",
+				"description": "Installation",
+				"type": "object",
+				"properties": {
+					"id": {
+						"description": "The ID of the installation.",
+						"type": "integer",
+						"example": 1
+					},
+					"account": {
+						"nullable": true,
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/simple-user"
+							},
+							{
+								"$ref": "#/components/schemas/enterprise"
+							}
+						]
+					},
+					"repository_selection": {
+						"description": "Describe whether all repositories have been selected or there's a selection involved",
+						"type": "string",
+						"enum": ["all", "selected"]
+					},
+					"access_tokens_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/app/installations/1/access_tokens"
+					},
+					"repositories_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/installation/repositories"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/organizations/github/settings/installations/1"
+					},
+					"app_id": {
+						"type": "integer",
+						"example": 1
+					},
+					"client_id": {
+						"type": "string",
+						"example": "Iv1.ab1112223334445c"
+					},
+					"target_id": {
+						"description": "The ID of the user or organization this token is being scoped to.",
+						"type": "integer"
+					},
+					"target_type": {
+						"type": "string",
+						"example": "Organization"
+					},
+					"permissions": {
+						"$ref": "#/components/schemas/app-permissions"
+					},
+					"events": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"created_at": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"single_file_name": {
+						"type": "string",
+						"example": "config.yaml",
+						"nullable": true
+					},
+					"has_multiple_single_files": {
+						"type": "boolean",
+						"example": true
+					},
+					"single_file_paths": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"example": ["config.yml", ".github/issue_TEMPLATE.md"]
+					},
+					"app_slug": {
+						"type": "string",
+						"example": "github-actions"
+					},
+					"suspended_by": {
+						"$ref": "#/components/schemas/nullable-simple-user"
+					},
+					"suspended_at": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
+					},
+					"contact_email": {
+						"type": "string",
+						"example": "\"test_13f1e99741e3e004@d7e1eb0bc0a1ba12.com\"",
+						"nullable": true
+					}
+				},
+				"required": [
+					"id",
+					"app_id",
+					"app_slug",
+					"target_id",
+					"target_type",
+					"single_file_name",
+					"repository_selection",
+					"access_tokens_url",
+					"html_url",
+					"repositories_url",
+					"events",
+					"account",
+					"permissions",
+					"created_at",
+					"updated_at",
+					"suspended_by",
+					"suspended_at"
+				]
+			},
+			"repository": {
+				"title": "Repository",
+				"description": "A repository on GitHub.",
+				"type": "object",
+				"properties": {
+					"id": {
+						"description": "Unique identifier of the repository",
+						"example": 42,
+						"type": "integer",
+						"format": "int64"
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5"
+					},
+					"name": {
+						"description": "The name of the repository.",
+						"type": "string",
+						"example": "Team Environment"
+					},
+					"full_name": {
+						"type": "string",
+						"example": "octocat/Hello-World"
+					},
+					"license": {
+						"$ref": "#/components/schemas/nullable-license-simple"
+					},
+					"forks": {
+						"type": "integer"
+					},
+					"permissions": {
+						"type": "object",
+						"properties": {
+							"admin": {
+								"type": "boolean"
+							},
+							"pull": {
+								"type": "boolean"
+							},
+							"triage": {
+								"type": "boolean"
+							},
+							"push": {
+								"type": "boolean"
+							},
+							"maintain": {
+								"type": "boolean"
+							}
+						},
+						"required": ["admin", "pull", "push"]
+					},
+					"owner": {
+						"$ref": "#/components/schemas/simple-user"
+					},
+					"private": {
+						"description": "Whether the repository is private or public.",
+						"default": false,
+						"type": "boolean"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/octocat/Hello-World"
+					},
+					"description": {
+						"type": "string",
+						"example": "This your first repo!",
+						"nullable": true
+					},
+					"fork": {
+						"type": "boolean"
+					},
+					"url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/repos/octocat/Hello-World"
+					},
+					"archive_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}"
+					},
+					"assignees_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}"
+					},
+					"blobs_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}"
+					},
+					"branches_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}"
+					},
+					"collaborators_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}"
+					},
+					"comments_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/comments{/number}"
+					},
+					"commits_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}"
+					},
+					"compare_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}"
+					},
+					"contents_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}"
+					},
+					"contributors_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/contributors"
+					},
+					"deployments_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/deployments"
+					},
+					"downloads_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/downloads"
+					},
+					"events_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/events"
+					},
+					"forks_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/forks"
+					},
+					"git_commits_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}"
+					},
+					"git_refs_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}"
+					},
+					"git_tags_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}"
+					},
+					"git_url": {
+						"type": "string",
+						"example": "git:github.com/octocat/Hello-World.git"
+					},
+					"issue_comment_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}"
+					},
+					"issue_events_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}"
+					},
+					"issues_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/issues{/number}"
+					},
+					"keys_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}"
+					},
+					"labels_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/labels{/name}"
+					},
+					"languages_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/languages"
+					},
+					"merges_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/merges"
+					},
+					"milestones_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}"
+					},
+					"notifications_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}"
+					},
+					"pulls_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}"
+					},
+					"releases_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/releases{/id}"
+					},
+					"ssh_url": {
+						"type": "string",
+						"example": "git@github.com:octocat/Hello-World.git"
+					},
+					"stargazers_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/stargazers"
+					},
+					"statuses_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}"
+					},
+					"subscribers_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/subscribers"
+					},
+					"subscription_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/subscription"
+					},
+					"tags_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/tags"
+					},
+					"teams_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/teams"
+					},
+					"trees_url": {
+						"type": "string",
+						"example": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}"
+					},
+					"clone_url": {
+						"type": "string",
+						"example": "https://github.com/octocat/Hello-World.git"
+					},
+					"mirror_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "git:git.example.com/octocat/Hello-World",
+						"nullable": true
+					},
+					"hooks_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "http://api.github.com/repos/octocat/Hello-World/hooks"
+					},
+					"svn_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://svn.github.com/octocat/Hello-World"
+					},
+					"homepage": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com",
+						"nullable": true
+					},
+					"language": {
+						"type": "string",
+						"nullable": true
+					},
+					"forks_count": {
+						"type": "integer",
+						"example": 9
+					},
+					"stargazers_count": {
+						"type": "integer",
+						"example": 80
+					},
+					"watchers_count": {
+						"type": "integer",
+						"example": 80
+					},
+					"size": {
+						"description": "The size of the repository, in kilobytes. Size is calculated hourly. When a repository is initially created, the size is 0.",
+						"type": "integer",
+						"example": 108
+					},
+					"default_branch": {
+						"description": "The default branch of the repository.",
+						"type": "string",
+						"example": "master"
+					},
+					"open_issues_count": {
+						"type": "integer",
+						"example": 0
+					},
+					"is_template": {
+						"description": "Whether this repository acts as a template that can be used to generate new repositories.",
+						"default": false,
+						"type": "boolean",
+						"example": true
+					},
+					"topics": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"has_issues": {
+						"description": "Whether issues are enabled.",
+						"default": true,
+						"type": "boolean",
+						"example": true
+					},
+					"has_projects": {
+						"description": "Whether projects are enabled.",
+						"default": true,
+						"type": "boolean",
+						"example": true
+					},
+					"has_wiki": {
+						"description": "Whether the wiki is enabled.",
+						"default": true,
+						"type": "boolean",
+						"example": true
+					},
+					"has_pages": {
+						"type": "boolean"
+					},
+					"has_downloads": {
+						"description": "Whether downloads are enabled.",
+						"default": true,
+						"type": "boolean",
+						"example": true,
+						"deprecated": true
+					},
+					"has_discussions": {
+						"description": "Whether discussions are enabled.",
+						"default": false,
+						"type": "boolean",
+						"example": true
+					},
+					"archived": {
+						"description": "Whether the repository is archived.",
+						"default": false,
+						"type": "boolean"
+					},
+					"disabled": {
+						"type": "boolean",
+						"description": "Returns whether or not this repository disabled."
+					},
+					"visibility": {
+						"description": "The repository visibility: public, private, or internal.",
+						"default": "public",
+						"type": "string"
+					},
+					"pushed_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2011-01-26T19:06:43Z",
+						"nullable": true
+					},
+					"created_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2011-01-26T19:01:12Z",
+						"nullable": true
+					},
+					"updated_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2011-01-26T19:14:43Z",
+						"nullable": true
+					},
+					"allow_rebase_merge": {
+						"description": "Whether to allow rebase merges for pull requests.",
+						"default": true,
+						"type": "boolean",
+						"example": true
+					},
+					"temp_clone_token": {
+						"type": "string"
+					},
+					"allow_squash_merge": {
+						"description": "Whether to allow squash merges for pull requests.",
+						"default": true,
+						"type": "boolean",
+						"example": true
+					},
+					"allow_auto_merge": {
+						"description": "Whether to allow Auto-merge to be used on pull requests.",
+						"default": false,
+						"type": "boolean",
+						"example": false
+					},
+					"delete_branch_on_merge": {
+						"description": "Whether to delete head branches when pull requests are merged",
+						"default": false,
+						"type": "boolean",
+						"example": false
+					},
+					"allow_update_branch": {
+						"description": "Whether or not a pull request head branch that is behind its base branch can always be updated even if it is not required to be up to date before merging.",
+						"default": false,
+						"type": "boolean",
+						"example": false
+					},
+					"use_squash_pr_title_as_default": {
+						"type": "boolean",
+						"description": "Whether a squash merge commit can use the pull request title as default. **This property is closing down. Please use `squash_merge_commit_title` instead.",
+						"default": false,
+						"deprecated": true
+					},
+					"squash_merge_commit_title": {
+						"type": "string",
+						"enum": ["PR_TITLE", "COMMIT_OR_PR_TITLE"],
+						"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit)."
+					},
+					"squash_merge_commit_message": {
+						"type": "string",
+						"enum": ["PR_BODY", "COMMIT_MESSAGES", "BLANK"],
+						"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message."
+					},
+					"merge_commit_title": {
+						"type": "string",
+						"enum": ["PR_TITLE", "MERGE_MESSAGE"],
+						"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name)."
+					},
+					"merge_commit_message": {
+						"type": "string",
+						"enum": ["PR_BODY", "PR_TITLE", "BLANK"],
+						"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message."
+					},
+					"allow_merge_commit": {
+						"description": "Whether to allow merge commits for pull requests.",
+						"default": true,
+						"type": "boolean",
+						"example": true
+					},
+					"allow_forking": {
+						"description": "Whether to allow forking this repo",
+						"type": "boolean"
+					},
+					"web_commit_signoff_required": {
+						"description": "Whether to require contributors to sign off on web-based commits",
+						"default": false,
+						"type": "boolean"
+					},
+					"open_issues": {
+						"type": "integer"
+					},
+					"watchers": {
+						"type": "integer"
+					},
+					"master_branch": {
+						"type": "string"
+					},
+					"starred_at": {
+						"type": "string",
+						"example": "\"2020-07-09T00:17:42Z\""
+					},
+					"anonymous_access_enabled": {
+						"type": "boolean",
+						"description": "Whether anonymous git access is enabled for this repository"
+					},
+					"code_search_index_status": {
+						"type": "object",
+						"description": "The status of the code search index for this repository",
+						"properties": {
+							"lexical_search_ok": {
+								"type": "boolean"
+							},
+							"lexical_commit_sha": {
+								"type": "string"
+							}
+						}
+					}
+				},
+				"required": [
+					"archive_url",
+					"assignees_url",
+					"blobs_url",
+					"branches_url",
+					"collaborators_url",
+					"comments_url",
+					"commits_url",
+					"compare_url",
+					"contents_url",
+					"contributors_url",
+					"deployments_url",
+					"description",
+					"downloads_url",
+					"events_url",
+					"fork",
+					"forks_url",
+					"full_name",
+					"git_commits_url",
+					"git_refs_url",
+					"git_tags_url",
+					"hooks_url",
+					"html_url",
+					"id",
+					"node_id",
+					"issue_comment_url",
+					"issue_events_url",
+					"issues_url",
+					"keys_url",
+					"labels_url",
+					"languages_url",
+					"merges_url",
+					"milestones_url",
+					"name",
+					"notifications_url",
+					"owner",
+					"private",
+					"pulls_url",
+					"releases_url",
+					"stargazers_url",
+					"statuses_url",
+					"subscribers_url",
+					"subscription_url",
+					"tags_url",
+					"teams_url",
+					"trees_url",
+					"url",
+					"clone_url",
+					"default_branch",
+					"forks",
+					"forks_count",
+					"git_url",
+					"has_downloads",
+					"has_issues",
+					"has_projects",
+					"has_wiki",
+					"has_pages",
+					"homepage",
+					"language",
+					"archived",
+					"disabled",
+					"mirror_url",
+					"open_issues",
+					"open_issues_count",
+					"license",
+					"pushed_at",
+					"size",
+					"ssh_url",
+					"stargazers_count",
+					"svn_url",
+					"watchers",
+					"watchers_count",
+					"created_at",
+					"updated_at"
+				]
+			},
+			"issue": {
+				"title": "Issue",
+				"description": "Issues are a great way to keep track of tasks, enhancements, and bugs for your projects.",
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"node_id": {
+						"type": "string"
+					},
+					"url": {
+						"description": "URL for the issue",
+						"example": "https://api.github.com/repositories/42/issues/1",
+						"type": "string",
+						"format": "uri"
+					},
+					"repository_url": {
+						"type": "string",
+						"format": "uri"
+					},
+					"labels_url": {
+						"type": "string"
+					},
+					"comments_url": {
+						"type": "string",
+						"format": "uri"
+					},
+					"events_url": {
+						"type": "string",
+						"format": "uri"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri"
+					},
+					"number": {
+						"description": "Number uniquely identifying the issue within its repository",
+						"example": 42,
+						"type": "integer"
+					},
+					"state": {
+						"description": "State of the issue; either 'open' or 'closed'",
+						"example": "open",
+						"type": "string"
+					},
+					"state_reason": {
+						"description": "The reason for the current state",
+						"example": "not_planned",
+						"type": "string",
+						"nullable": true,
+						"enum": ["completed", "reopened", "not_planned", "duplicate"]
+					},
+					"title": {
+						"description": "Title of the issue",
+						"example": "Widget creation fails in Safari on OS X 10.8",
+						"type": "string"
+					},
+					"body": {
+						"description": "Contents of the issue",
+						"example": "It looks like the new widget form is broken on Safari. When I try and create the widget, Safari crashes. This is reproducible on 10.8, but not 10.9. Maybe a browser bug?",
+						"type": "string",
+						"nullable": true
+					},
+					"user": {
+						"$ref": "#/components/schemas/nullable-simple-user"
+					},
+					"labels": {
+						"description": "Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository",
+						"example": ["bug", "registration"],
+						"type": "array",
+						"items": {
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "object",
+									"properties": {
+										"id": {
+											"type": "integer",
+											"format": "int64"
+										},
+										"node_id": {
+											"type": "string"
+										},
+										"url": {
+											"type": "string",
+											"format": "uri"
+										},
+										"name": {
+											"type": "string"
+										},
+										"description": {
+											"type": "string",
+											"nullable": true
+										},
+										"color": {
+											"type": "string",
+											"nullable": true
+										},
+										"default": {
+											"type": "boolean"
+										}
+									}
+								}
+							]
+						}
+					},
+					"assignee": {
+						"$ref": "#/components/schemas/nullable-simple-user"
+					},
+					"assignees": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/simple-user"
+						},
+						"nullable": true
+					},
+					"milestone": {
+						"$ref": "#/components/schemas/nullable-milestone"
+					},
+					"locked": {
+						"type": "boolean"
+					},
+					"active_lock_reason": {
+						"type": "string",
+						"nullable": true
+					},
+					"comments": {
+						"type": "integer"
+					},
+					"pull_request": {
+						"type": "object",
+						"properties": {
+							"merged_at": {
+								"type": "string",
+								"format": "date-time",
+								"nullable": true
+							},
+							"diff_url": {
+								"type": "string",
+								"format": "uri",
+								"nullable": true
+							},
+							"html_url": {
+								"type": "string",
+								"format": "uri",
+								"nullable": true
+							},
+							"patch_url": {
+								"type": "string",
+								"format": "uri",
+								"nullable": true
+							},
+							"url": {
+								"type": "string",
+								"format": "uri",
+								"nullable": true
+							}
+						},
+						"required": ["diff_url", "html_url", "patch_url", "url"]
+					},
+					"closed_at": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
+					},
+					"created_at": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"draft": {
+						"type": "boolean"
+					},
+					"closed_by": {
+						"$ref": "#/components/schemas/nullable-simple-user"
+					},
+					"body_html": {
+						"type": "string"
+					},
+					"body_text": {
+						"type": "string"
+					},
+					"timeline_url": {
+						"type": "string",
+						"format": "uri"
+					},
+					"type": {
+						"$ref": "#/components/schemas/issue-type"
+					},
+					"repository": {
+						"$ref": "#/components/schemas/repository"
+					},
+					"performed_via_github_app": {
+						"$ref": "#/components/schemas/nullable-integration"
+					},
+					"author_association": {
+						"$ref": "#/components/schemas/author-association"
+					},
+					"reactions": {
+						"$ref": "#/components/schemas/reaction-rollup"
+					},
+					"sub_issues_summary": {
+						"$ref": "#/components/schemas/sub-issues-summary"
+					},
+					"parent_issue_url": {
+						"description": "URL to get the parent issue of this issue, if it is a sub-issue",
+						"type": "string",
+						"format": "uri",
+						"nullable": true
+					},
+					"issue_dependencies_summary": {
+						"$ref": "#/components/schemas/issue-dependencies-summary"
+					},
+					"issue_field_values": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/issue-field-value"
+						}
+					}
+				},
+				"required": [
+					"assignee",
+					"closed_at",
+					"comments",
+					"comments_url",
+					"events_url",
+					"html_url",
+					"id",
+					"node_id",
+					"labels",
+					"labels_url",
+					"milestone",
+					"number",
+					"repository_url",
+					"state",
+					"locked",
+					"title",
+					"url",
+					"user",
+					"created_at",
+					"updated_at"
+				]
+			},
+			"simple-user": {
+				"title": "Simple User",
+				"description": "A GitHub user.",
+				"type": "object",
+				"properties": {
+					"name": {
+						"nullable": true,
+						"type": "string"
+					},
+					"email": {
+						"nullable": true,
+						"type": "string"
+					},
+					"login": {
+						"type": "string",
+						"example": "octocat"
+					},
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 1
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDQ6VXNlcjE="
+					},
+					"avatar_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/images/error/octocat_happy.gif"
+					},
+					"gravatar_id": {
+						"type": "string",
+						"example": "41d064eb2195891e12d0413f63227ea7",
+						"nullable": true
+					},
+					"url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/octocat"
+					},
+					"followers_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/followers"
+					},
+					"following_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/following{/other_user}"
+					},
+					"gists_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/gists{/gist_id}"
+					},
+					"starred_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/starred{/owner}{/repo}"
+					},
+					"subscriptions_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/subscriptions"
+					},
+					"organizations_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/orgs"
+					},
+					"repos_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/repos"
+					},
+					"events_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/events{/privacy}"
+					},
+					"received_events_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/received_events"
+					},
+					"type": {
+						"type": "string",
+						"example": "User"
+					},
+					"site_admin": {
+						"type": "boolean"
+					},
+					"starred_at": {
+						"type": "string",
+						"example": "\"2020-07-09T00:17:55Z\""
+					},
+					"user_view_type": {
+						"type": "string",
+						"example": "public"
+					}
+				},
+				"required": [
+					"avatar_url",
+					"events_url",
+					"followers_url",
+					"following_url",
+					"gists_url",
+					"gravatar_id",
+					"html_url",
+					"id",
+					"node_id",
+					"login",
+					"organizations_url",
+					"received_events_url",
+					"repos_url",
+					"site_admin",
+					"starred_url",
+					"subscriptions_url",
+					"type",
+					"url"
+				]
+			},
+			"enterprise": {
+				"title": "Enterprise",
+				"description": "An enterprise on GitHub.",
+				"type": "object",
+				"properties": {
+					"description": {
+						"description": "A short description of the enterprise.",
+						"type": "string",
+						"nullable": true
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/enterprises/octo-business"
+					},
+					"website_url": {
+						"description": "The enterprise's website URL.",
+						"type": "string",
+						"nullable": true,
+						"format": "uri"
+					},
+					"id": {
+						"description": "Unique identifier of the enterprise",
+						"example": 42,
+						"type": "integer"
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5"
+					},
+					"name": {
+						"description": "The name of the enterprise.",
+						"type": "string",
+						"example": "Octo Business"
+					},
+					"slug": {
+						"description": "The slug url identifier for the enterprise.",
+						"type": "string",
+						"example": "octo-business"
+					},
+					"created_at": {
+						"type": "string",
+						"nullable": true,
+						"format": "date-time",
+						"example": "2019-01-26T19:01:12Z"
+					},
+					"updated_at": {
+						"type": "string",
+						"nullable": true,
+						"format": "date-time",
+						"example": "2019-01-26T19:14:43Z"
+					},
+					"avatar_url": {
+						"type": "string",
+						"format": "uri"
+					}
+				},
+				"required": [
+					"id",
+					"node_id",
+					"name",
+					"slug",
+					"html_url",
+					"created_at",
+					"updated_at",
+					"avatar_url"
+				]
+			},
+			"app-permissions": {
+				"title": "App Permissions",
+				"type": "object",
+				"description": "The permissions granted to the user access token.",
+				"properties": {
+					"actions": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts.",
+						"enum": ["read", "write"]
+					},
+					"administration": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for repository creation, deletion, settings, teams, and collaborators creation.",
+						"enum": ["read", "write"]
+					},
+					"artifact_metadata": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to create and retrieve build artifact metadata records.",
+						"enum": ["read", "write"]
+					},
+					"attestations": {
+						"type": "string",
+						"description": "The level of permission to create and retrieve the access token for repository attestations.",
+						"enum": ["read", "write"]
+					},
+					"checks": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for checks on code.",
+						"enum": ["read", "write"]
+					},
+					"codespaces": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to create, edit, delete, and list Codespaces.",
+						"enum": ["read", "write"]
+					},
+					"contents": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for repository contents, commits, branches, downloads, releases, and merges.",
+						"enum": ["read", "write"]
+					},
+					"dependabot_secrets": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage Dependabot secrets.",
+						"enum": ["read", "write"]
+					},
+					"deployments": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for deployments and deployment statuses.",
+						"enum": ["read", "write"]
+					},
+					"discussions": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for discussions and related comments and labels.",
+						"enum": ["read", "write"]
+					},
+					"environments": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for managing repository environments.",
+						"enum": ["read", "write"]
+					},
+					"issues": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.",
+						"enum": ["read", "write"]
+					},
+					"merge_queues": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage the merge queues for a repository.",
+						"enum": ["read", "write"]
+					},
+					"metadata": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.",
+						"enum": ["read", "write"]
+					},
+					"packages": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for packages published to GitHub Packages.",
+						"enum": ["read", "write"]
+					},
+					"pages": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.",
+						"enum": ["read", "write"]
+					},
+					"pull_requests": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.",
+						"enum": ["read", "write"]
+					},
+					"repository_custom_properties": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and edit custom properties for a repository, when allowed by the property.",
+						"enum": ["read", "write"]
+					},
+					"repository_hooks": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage the post-receive hooks for a repository.",
+						"enum": ["read", "write"]
+					},
+					"repository_projects": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage repository projects, columns, and cards.",
+						"enum": ["read", "write", "admin"]
+					},
+					"secret_scanning_alerts": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage secret scanning alerts.",
+						"enum": ["read", "write"]
+					},
+					"secrets": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage repository secrets.",
+						"enum": ["read", "write"]
+					},
+					"security_events": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage security events like code scanning alerts.",
+						"enum": ["read", "write"]
+					},
+					"single_file": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage just a single file.",
+						"enum": ["read", "write"]
+					},
+					"statuses": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for commit statuses.",
+						"enum": ["read", "write"]
+					},
+					"vulnerability_alerts": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage Dependabot alerts.",
+						"enum": ["read", "write"]
+					},
+					"workflows": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to update GitHub Actions workflow files.",
+						"enum": ["write"]
+					},
+					"custom_properties_for_organizations": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and edit custom properties for an organization, when allowed by the property.",
+						"enum": ["read", "write"]
+					},
+					"members": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for organization teams and members.",
+						"enum": ["read", "write"]
+					},
+					"organization_administration": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage access to an organization.",
+						"enum": ["read", "write"]
+					},
+					"organization_custom_roles": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for custom repository roles management.",
+						"enum": ["read", "write"]
+					},
+					"organization_custom_org_roles": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for custom organization roles management.",
+						"enum": ["read", "write"]
+					},
+					"organization_custom_properties": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for repository custom properties management at the organization level.",
+						"enum": ["read", "write", "admin"]
+					},
+					"organization_copilot_seat_management": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for managing access to GitHub Copilot for members of an organization with a Copilot Business subscription. This property is in public preview and is subject to change.",
+						"enum": ["write"]
+					},
+					"organization_announcement_banners": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage announcement banners for an organization.",
+						"enum": ["read", "write"]
+					},
+					"organization_events": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view events triggered by an activity in an organization.",
+						"enum": ["read"]
+					},
+					"organization_hooks": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage the post-receive hooks for an organization.",
+						"enum": ["read", "write"]
+					},
+					"organization_personal_access_tokens": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.",
+						"enum": ["read", "write"]
+					},
+					"organization_personal_access_token_requests": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.",
+						"enum": ["read", "write"]
+					},
+					"organization_plan": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for viewing an organization's plan.",
+						"enum": ["read"]
+					},
+					"organization_projects": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage organization projects and projects public preview (where available).",
+						"enum": ["read", "write", "admin"]
+					},
+					"organization_packages": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for organization packages published to GitHub Packages.",
+						"enum": ["read", "write"]
+					},
+					"organization_secrets": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage organization secrets.",
+						"enum": ["read", "write"]
+					},
+					"organization_self_hosted_runners": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.",
+						"enum": ["read", "write"]
+					},
+					"organization_user_blocking": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
+						"enum": ["read", "write"]
+					},
+					"team_discussions": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage team discussions and related comments.",
+						"enum": ["read", "write"]
+					},
+					"email_addresses": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage the email addresses belonging to a user.",
+						"enum": ["read", "write"]
+					},
+					"followers": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage the followers belonging to a user.",
+						"enum": ["read", "write"]
+					},
+					"git_ssh_keys": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage git SSH keys.",
+						"enum": ["read", "write"]
+					},
+					"gpg_keys": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage GPG keys belonging to a user.",
+						"enum": ["read", "write"]
+					},
+					"interaction_limits": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to view and manage interaction limits on a repository.",
+						"enum": ["read", "write"]
+					},
+					"profile": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to manage the profile settings belonging to a user.",
+						"enum": ["write"]
+					},
+					"starring": {
+						"type": "string",
+						"description": "The level of permission to grant the access token to list and manage repositories a user is starring.",
+						"enum": ["read", "write"]
+					},
+					"enterprise_custom_properties_for_organizations": {
+						"type": "string",
+						"description": "The level of permission to grant the access token for organization custom properties management at the enterprise level.",
+						"enum": ["read", "write", "admin"]
+					}
+				},
+				"example": {
+					"contents": "read",
+					"issues": "read",
+					"deployments": "write",
+					"single_file": "read"
+				}
+			},
+			"nullable-simple-user": {
+				"title": "Simple User",
+				"description": "A GitHub user.",
+				"type": "object",
+				"properties": {
+					"name": {
+						"nullable": true,
+						"type": "string"
+					},
+					"email": {
+						"nullable": true,
+						"type": "string"
+					},
+					"login": {
+						"type": "string",
+						"example": "octocat"
+					},
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 1
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDQ6VXNlcjE="
+					},
+					"avatar_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/images/error/octocat_happy.gif"
+					},
+					"gravatar_id": {
+						"type": "string",
+						"example": "41d064eb2195891e12d0413f63227ea7",
+						"nullable": true
+					},
+					"url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/octocat"
+					},
+					"followers_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/followers"
+					},
+					"following_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/following{/other_user}"
+					},
+					"gists_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/gists{/gist_id}"
+					},
+					"starred_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/starred{/owner}{/repo}"
+					},
+					"subscriptions_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/subscriptions"
+					},
+					"organizations_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/orgs"
+					},
+					"repos_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/repos"
+					},
+					"events_url": {
+						"type": "string",
+						"example": "https://api.github.com/users/octocat/events{/privacy}"
+					},
+					"received_events_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/users/octocat/received_events"
+					},
+					"type": {
+						"type": "string",
+						"example": "User"
+					},
+					"site_admin": {
+						"type": "boolean"
+					},
+					"starred_at": {
+						"type": "string",
+						"example": "\"2020-07-09T00:17:55Z\""
+					},
+					"user_view_type": {
+						"type": "string",
+						"example": "public"
+					}
+				},
+				"required": [
+					"avatar_url",
+					"events_url",
+					"followers_url",
+					"following_url",
+					"gists_url",
+					"gravatar_id",
+					"html_url",
+					"id",
+					"node_id",
+					"login",
+					"organizations_url",
+					"received_events_url",
+					"repos_url",
+					"site_admin",
+					"starred_url",
+					"subscriptions_url",
+					"type",
+					"url"
+				],
+				"nullable": true
+			},
+			"nullable-license-simple": {
+				"title": "License Simple",
+				"description": "License Simple",
+				"type": "object",
+				"properties": {
+					"key": {
+						"type": "string",
+						"example": "mit"
+					},
+					"name": {
+						"type": "string",
+						"example": "MIT License"
+					},
+					"url": {
+						"type": "string",
+						"nullable": true,
+						"format": "uri",
+						"example": "https://api.github.com/licenses/mit"
+					},
+					"spdx_id": {
+						"type": "string",
+						"nullable": true,
+						"example": "MIT"
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDc6TGljZW5zZW1pdA=="
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri"
+					}
+				},
+				"required": ["key", "name", "url", "spdx_id", "node_id"],
+				"nullable": true
+			},
+			"nullable-milestone": {
+				"title": "Milestone",
+				"description": "A collection of related issues and pull requests.",
+				"type": "object",
+				"properties": {
+					"url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/repos/octocat/Hello-World/milestones/1"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/octocat/Hello-World/milestones/v1.0"
+					},
+					"labels_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://api.github.com/repos/octocat/Hello-World/milestones/1/labels"
+					},
+					"id": {
+						"type": "integer",
+						"example": 1002604
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDk6TWlsZXN0b25lMTAwMjYwNA=="
+					},
+					"number": {
+						"description": "The number of the milestone.",
+						"type": "integer",
+						"example": 42
+					},
+					"state": {
+						"description": "The state of the milestone.",
+						"example": "open",
+						"type": "string",
+						"enum": ["open", "closed"],
+						"default": "open"
+					},
+					"title": {
+						"description": "The title of the milestone.",
+						"example": "v1.0",
+						"type": "string"
+					},
+					"description": {
+						"type": "string",
+						"example": "Tracking milestone for version 1.0",
+						"nullable": true
+					},
+					"creator": {
+						"$ref": "#/components/schemas/nullable-simple-user"
+					},
+					"open_issues": {
+						"type": "integer",
+						"example": 4
+					},
+					"closed_issues": {
+						"type": "integer",
+						"example": 8
+					},
+					"created_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2011-04-10T20:09:31Z"
+					},
+					"updated_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2014-03-03T18:58:10Z"
+					},
+					"closed_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2013-02-12T13:22:01Z",
+						"nullable": true
+					},
+					"due_on": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2012-10-09T23:39:01Z",
+						"nullable": true
+					}
+				},
+				"required": [
+					"closed_issues",
+					"creator",
+					"description",
+					"due_on",
+					"closed_at",
+					"id",
+					"node_id",
+					"labels_url",
+					"html_url",
+					"number",
+					"open_issues",
+					"state",
+					"title",
+					"url",
+					"created_at",
+					"updated_at"
+				],
+				"nullable": true
+			},
+			"issue-type": {
+				"title": "Issue Type",
+				"description": "The type of issue.",
+				"type": "object",
+				"nullable": true,
+				"properties": {
+					"id": {
+						"type": "integer",
+						"description": "The unique identifier of the issue type."
+					},
+					"node_id": {
+						"type": "string",
+						"description": "The node identifier of the issue type."
+					},
+					"name": {
+						"type": "string",
+						"description": "The name of the issue type."
+					},
+					"description": {
+						"type": "string",
+						"description": "The description of the issue type.",
+						"nullable": true
+					},
+					"color": {
+						"type": "string",
+						"description": "The color of the issue type.",
+						"enum": [
+							"gray",
+							"blue",
+							"green",
+							"yellow",
+							"orange",
+							"red",
+							"pink",
+							"purple"
+						],
+						"nullable": true
+					},
+					"created_at": {
+						"type": "string",
+						"description": "The time the issue type created.",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"type": "string",
+						"description": "The time the issue type last updated.",
+						"format": "date-time"
+					},
+					"is_enabled": {
+						"type": "boolean",
+						"description": "The enabled state of the issue type."
+					}
+				},
+				"required": ["id", "node_id", "name", "description"]
+			},
+			"nullable-integration": {
+				"title": "GitHub app",
+				"description": "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub.",
+				"type": "object",
+				"nullable": true,
+				"properties": {
+					"id": {
+						"description": "Unique identifier of the GitHub app",
+						"example": 37,
+						"type": "integer"
+					},
+					"slug": {
+						"description": "The slug name of the GitHub app",
+						"example": "probot-owners",
+						"type": "string"
+					},
+					"node_id": {
+						"type": "string",
+						"example": "MDExOkludGVncmF0aW9uMQ=="
+					},
+					"client_id": {
+						"type": "string",
+						"example": "\"Iv1.25b5d1e65ffc4022\""
+					},
+					"owner": {
+						"oneOf": [
+							{
+								"$ref": "#/components/schemas/simple-user"
+							},
+							{
+								"$ref": "#/components/schemas/enterprise"
+							}
+						]
+					},
+					"name": {
+						"description": "The name of the GitHub app",
+						"example": "Probot Owners",
+						"type": "string"
+					},
+					"description": {
+						"type": "string",
+						"example": "The description of the app.",
+						"nullable": true
+					},
+					"external_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://example.com"
+					},
+					"html_url": {
+						"type": "string",
+						"format": "uri",
+						"example": "https://github.com/apps/super-ci"
+					},
+					"created_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2017-07-08T16:18:44-04:00"
+					},
+					"updated_at": {
+						"type": "string",
+						"format": "date-time",
+						"example": "2017-07-08T16:18:44-04:00"
+					},
+					"permissions": {
+						"description": "The set of permissions for the GitHub app",
+						"type": "object",
+						"properties": {
+							"issues": {
+								"type": "string"
+							},
+							"checks": {
+								"type": "string"
+							},
+							"metadata": {
+								"type": "string"
+							},
+							"contents": {
+								"type": "string"
+							},
+							"deployments": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": {
+							"type": "string"
+						},
+						"example": {
+							"issues": "read",
+							"deployments": "write"
+						}
+					},
+					"events": {
+						"description": "The list of events for the GitHub app. Note that the `installation_target`, `security_advisory`, and `meta` events are not included because they are global events and not specific to an installation.",
+						"example": ["label", "deployment"],
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"installations_count": {
+						"description": "The number of installations associated with the GitHub app. Only returned when the integration is requesting details about itself.",
+						"example": 5,
+						"type": "integer"
+					}
+				},
+				"required": [
+					"id",
+					"node_id",
+					"owner",
+					"name",
+					"description",
+					"external_url",
+					"html_url",
+					"created_at",
+					"updated_at",
+					"permissions",
+					"events"
+				]
+			},
+			"author-association": {
+				"title": "author_association",
+				"type": "string",
+				"example": "OWNER",
+				"description": "How the author is associated with the repository.",
+				"enum": [
+					"COLLABORATOR",
+					"CONTRIBUTOR",
+					"FIRST_TIMER",
+					"FIRST_TIME_CONTRIBUTOR",
+					"MANNEQUIN",
+					"MEMBER",
+					"NONE",
+					"OWNER"
+				]
+			},
+			"reaction-rollup": {
+				"title": "Reaction Rollup",
+				"type": "object",
+				"properties": {
+					"url": {
+						"type": "string",
+						"format": "uri"
+					},
+					"total_count": {
+						"type": "integer"
+					},
+					"+1": {
+						"type": "integer"
+					},
+					"-1": {
+						"type": "integer"
+					},
+					"laugh": {
+						"type": "integer"
+					},
+					"confused": {
+						"type": "integer"
+					},
+					"heart": {
+						"type": "integer"
+					},
+					"hooray": {
+						"type": "integer"
+					},
+					"eyes": {
+						"type": "integer"
+					},
+					"rocket": {
+						"type": "integer"
+					}
+				},
+				"required": [
+					"url",
+					"total_count",
+					"+1",
+					"-1",
+					"laugh",
+					"confused",
+					"heart",
+					"hooray",
+					"eyes",
+					"rocket"
+				]
+			},
+			"sub-issues-summary": {
+				"title": "Sub-issues Summary",
+				"type": "object",
+				"properties": {
+					"total": {
+						"type": "integer"
+					},
+					"completed": {
+						"type": "integer"
+					},
+					"percent_completed": {
+						"type": "integer"
+					}
+				},
+				"required": ["total", "completed", "percent_completed"]
+			},
+			"issue-dependencies-summary": {
+				"title": "Issue Dependencies Summary",
+				"type": "object",
+				"properties": {
+					"blocked_by": {
+						"type": "integer"
+					},
+					"blocking": {
+						"type": "integer"
+					},
+					"total_blocked_by": {
+						"type": "integer"
+					},
+					"total_blocking": {
+						"type": "integer"
+					}
+				},
+				"required": [
+					"blocked_by",
+					"blocking",
+					"total_blocked_by",
+					"total_blocking"
+				]
+			},
+			"issue-field-value": {
+				"title": "Issue Field Value",
+				"description": "A value assigned to an issue field",
+				"type": "object",
+				"properties": {
+					"issue_field_id": {
+						"description": "Unique identifier for the issue field.",
+						"type": "integer",
+						"format": "int64",
+						"example": 1
+					},
+					"node_id": {
+						"type": "string",
+						"example": "IFT_GDKND"
+					},
+					"data_type": {
+						"description": "The data type of the issue field",
+						"type": "string",
+						"enum": ["text", "single_select", "number", "date"],
+						"example": "text"
+					},
+					"value": {
+						"description": "The value of the issue field",
+						"anyOf": [
+							{
+								"type": "string",
+								"example": "Sample text"
+							},
+							{
+								"type": "number",
+								"example": 42.5
+							},
+							{
+								"type": "integer",
+								"example": 1
+							}
+						],
+						"nullable": true
+					},
+					"single_select_option": {
+						"description": "Details about the selected option (only present for single_select fields)",
+						"type": "object",
+						"properties": {
+							"id": {
+								"description": "Unique identifier for the option.",
+								"type": "integer",
+								"format": "int64",
+								"example": 1
+							},
+							"name": {
+								"description": "The name of the option",
+								"type": "string",
+								"example": "High"
+							},
+							"color": {
+								"description": "The color of the option",
+								"type": "string",
+								"example": "red"
+							}
+						},
+						"required": ["id", "name", "color"],
+						"nullable": true
+					}
+				},
+				"required": ["issue_field_id", "node_id", "data_type", "value"]
+			},
+			"basic-error": {
+				"title": "Basic Error",
+				"description": "Basic Error",
+				"type": "object",
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"documentation_url": {
+						"type": "string"
+					},
+					"url": {
+						"type": "string"
+					},
+					"status": {
+						"type": "string"
+					}
+				}
+			},
+			"validation-error": {
+				"title": "Validation Error",
+				"description": "Validation Error",
+				"type": "object",
+				"required": ["message", "documentation_url"],
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"documentation_url": {
+						"type": "string"
+					},
+					"errors": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"required": ["code"],
+							"properties": {
+								"resource": {
+									"type": "string"
+								},
+								"field": {
+									"type": "string"
+								},
+								"message": {
+									"type": "string"
+								},
+								"code": {
+									"type": "string"
+								},
+								"index": {
+									"type": "integer"
+								},
+								"value": {
+									"oneOf": [
+										{
+											"type": "string",
+											"nullable": true
+										},
+										{
+											"type": "integer",
+											"nullable": true
+										},
+										{
+											"type": "array",
+											"nullable": true,
+											"items": {
+												"type": "string"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}
+			},
+			"scim-error": {
+				"title": "Scim Error",
+				"description": "Scim Error",
+				"type": "object",
+				"properties": {
+					"message": {
+						"type": "string",
+						"nullable": true
+					},
+					"documentation_url": {
+						"type": "string",
+						"nullable": true
+					},
+					"detail": {
+						"type": "string",
+						"nullable": true
+					},
+					"status": {
+						"type": "integer"
+					},
+					"scimType": {
+						"type": "string",
+						"nullable": true
+					},
+					"schemas": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			}
+		},
+		"parameters": {
+			"per-page": {
+				"name": "per_page",
+				"description": "The number of results per page (max 100). For more information, see \"[Using pagination in the REST API](https://docs.github.com/rest/using-the-rest-api/using-pagination-in-the-rest-api).\"",
+				"in": "query",
+				"schema": {
+					"type": "integer",
+					"default": 30
+				}
+			},
+			"page": {
+				"name": "page",
+				"description": "The page number of the results to fetch. For more information, see \"[Using pagination in the REST API](https://docs.github.com/rest/using-the-rest-api/using-pagination-in-the-rest-api).\"",
+				"in": "query",
+				"schema": {
+					"type": "integer",
+					"default": 1
+				}
+			},
+			"installation-id": {
+				"name": "installation_id",
+				"description": "The unique identifier of the installation.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "integer"
+				},
+				"examples": {
+					"default": {
+						"value": 1
+					}
+				}
+			},
+			"owner": {
+				"name": "owner",
+				"description": "The account owner of the repository. The name is not case sensitive.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			"repo": {
+				"name": "repo",
+				"description": "The name of the repository without the `.git` extension. The name is not case sensitive.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			"labels": {
+				"name": "labels",
+				"description": "A list of comma separated label names. Example: `bug,ui,@high`",
+				"in": "query",
+				"required": false,
+				"schema": {
+					"type": "string"
+				}
+			},
+			"direction": {
+				"name": "direction",
+				"description": "The direction to sort the results by.",
+				"in": "query",
+				"required": false,
+				"schema": {
+					"type": "string",
+					"enum": ["asc", "desc"],
+					"default": "desc"
+				}
+			},
+			"since": {
+				"name": "since",
+				"description": "Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.",
+				"in": "query",
+				"required": false,
+				"schema": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"responses": {
+			"not_modified": {
+				"description": "Not modified"
+			},
+			"requires_authentication": {
+				"description": "Requires authentication",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/basic-error"
+						}
+					}
+				}
+			},
+			"forbidden": {
+				"description": "Forbidden",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/basic-error"
+						}
+					}
+				}
+			},
+			"not_found": {
+				"description": "Resource not found",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/basic-error"
+						}
+					}
+				}
+			},
+			"moved_permanently": {
+				"description": "Moved permanently",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/basic-error"
+						}
+					}
+				}
+			},
+			"validation_failed": {
+				"description": "Validation failed, or the endpoint has been spammed.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/validation-error"
+						}
+					}
+				}
+			},
+			"bad_request": {
+				"description": "Bad Request",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/basic-error"
+						}
+					},
+					"application/scim+json": {
+						"schema": {
+							"$ref": "#/components/schemas/scim-error"
+						}
+					}
+				}
+			},
+			"gone": {
+				"description": "Gone",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/basic-error"
+						}
+					}
+				}
+			},
+			"service_unavailable": {
+				"description": "Service unavailable",
+				"content": {
+					"application/json": {
+						"schema": {
+							"type": "object",
+							"properties": {
+								"code": {
+									"type": "string"
+								},
+								"message": {
+									"type": "string"
+								},
+								"documentation_url": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"headers": {
+			"link": {
+				"example": "<https://api.github.com/resource?page=2>; rel=\"next\", <https://api.github.com/resource?page=5>; rel=\"last\"",
+				"schema": {
+					"type": "string"
+				}
+			}
+		},
+		"securitySchemes": {}
+	}
+}

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@packages/github-api",
+	"version": "0.1.0",
+	"type": "module",
+	"private": true,
+	"exports": {
+		"./generated": "./src/generated.ts"
+	},
+	"scripts": {
+		"clean": "rm -rf node_modules .turbo",
+		"typecheck": "tsgo -p tsconfig.json --noEmit",
+		"typecheck:slow": "tsc -p tsconfig.json --noEmit",
+		"sync": "bun run scripts/sync-openapi.ts",
+		"gen": "mkdir -p src && openapi-gen --spec ./open-api.json > ./src/generated.ts",
+		"update": "bun run sync && bun run gen"
+	},
+	"dependencies": {
+		"@effect/platform": "catalog:",
+		"@tim-smart/openapi-gen": "^0.4.13",
+		"effect": "catalog:"
+	}
+}

--- a/packages/github-api/scripts/sync-openapi.ts
+++ b/packages/github-api/scripts/sync-openapi.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env bun
+
+/**
+ * Sync script to fetch the latest GitHub REST API OpenAPI specification
+ * from GitHub's official repository and create a minimal subset for our needs.
+ *
+ * The full GitHub API spec is massive (~15MB), so we extract only the endpoints
+ * we actually use:
+ * - Apps: listInstallationsForAuthenticatedUser, listInstallationReposForAuthenticatedUser
+ * - Issues: create
+ * - OAuth: token refresh (manually defined since it's not in the REST API spec)
+ */
+
+const GITHUB_OPENAPI_URL =
+	"https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json";
+const OUTPUT_FILE = "./open-api.json";
+
+const PATHS_TO_KEEP = [
+	"/user/installations",
+	"/user/installations/{installation_id}/repositories",
+	"/repos/{owner}/{repo}/issues",
+];
+
+const collectRefs = (
+	obj: unknown,
+	schemaRefs: Set<string>,
+	parameterRefs: Set<string>,
+	responseRefs: Set<string>,
+	headerRefs: Set<string>,
+) => {
+	if (obj === null || obj === undefined) return;
+
+	if (typeof obj === "object") {
+		if (Array.isArray(obj)) {
+			for (const item of obj) {
+				collectRefs(item, schemaRefs, parameterRefs, responseRefs, headerRefs);
+			}
+		} else {
+			const record = obj as Record<string, unknown>;
+			if (record.$ref && typeof record.$ref === "string") {
+				const schemaMatch = record.$ref.match(/#\/components\/schemas\/(.+)/);
+				if (schemaMatch) schemaRefs.add(schemaMatch[1]);
+
+				const paramMatch = record.$ref.match(/#\/components\/parameters\/(.+)/);
+				if (paramMatch) parameterRefs.add(paramMatch[1]);
+
+				const responseMatch = record.$ref.match(
+					/#\/components\/responses\/(.+)/,
+				);
+				if (responseMatch) responseRefs.add(responseMatch[1]);
+
+				const headerMatch = record.$ref.match(/#\/components\/headers\/(.+)/);
+				if (headerMatch) headerRefs.add(headerMatch[1]);
+			}
+			for (const value of Object.values(record)) {
+				collectRefs(value, schemaRefs, parameterRefs, responseRefs, headerRefs);
+			}
+		}
+	}
+};
+
+const extractMinimalSpec = (
+	fullSpec: Record<string, unknown>,
+): Record<string, unknown> => {
+	const paths: Record<string, unknown> = {};
+	const usedSchemas = new Set<string>();
+	const usedParameters = new Set<string>();
+	const usedResponses = new Set<string>();
+	const usedHeaders = new Set<string>();
+
+	const fullPaths = fullSpec.paths as Record<string, unknown>;
+	const fullComponents = fullSpec.components as Record<string, unknown>;
+	const fullSchemas = (fullComponents?.schemas ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const fullParameters = (fullComponents?.parameters ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const fullResponses = (fullComponents?.responses ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const fullHeaders = (fullComponents?.headers ?? {}) as Record<
+		string,
+		unknown
+	>;
+
+	for (const pathKey of PATHS_TO_KEEP) {
+		if (fullPaths[pathKey]) {
+			paths[pathKey] = fullPaths[pathKey];
+			collectRefs(
+				fullPaths[pathKey],
+				usedSchemas,
+				usedParameters,
+				usedResponses,
+				usedHeaders,
+			);
+		}
+	}
+
+	const schemas: Record<string, unknown> = {};
+	const parameters: Record<string, unknown> = {};
+	const responses: Record<string, unknown> = {};
+	const headers: Record<string, unknown> = {};
+
+	const resolveAllRefs = () => {
+		let changed = true;
+		while (changed) {
+			changed = false;
+			const currentSchemas = [...usedSchemas];
+			const currentParams = [...usedParameters];
+			const currentResponses = [...usedResponses];
+			const currentHeaders = [...usedHeaders];
+
+			for (const name of currentSchemas) {
+				if (!schemas[name] && fullSchemas[name]) {
+					schemas[name] = fullSchemas[name];
+					collectRefs(
+						fullSchemas[name],
+						usedSchemas,
+						usedParameters,
+						usedResponses,
+						usedHeaders,
+					);
+					changed = true;
+				}
+			}
+
+			for (const name of currentParams) {
+				if (!parameters[name] && fullParameters[name]) {
+					parameters[name] = fullParameters[name];
+					collectRefs(
+						fullParameters[name],
+						usedSchemas,
+						usedParameters,
+						usedResponses,
+						usedHeaders,
+					);
+					changed = true;
+				}
+			}
+
+			for (const name of currentResponses) {
+				if (!responses[name] && fullResponses[name]) {
+					responses[name] = fullResponses[name];
+					collectRefs(
+						fullResponses[name],
+						usedSchemas,
+						usedParameters,
+						usedResponses,
+						usedHeaders,
+					);
+					changed = true;
+				}
+			}
+
+			for (const name of currentHeaders) {
+				if (!headers[name] && fullHeaders[name]) {
+					headers[name] = fullHeaders[name];
+					collectRefs(
+						fullHeaders[name],
+						usedSchemas,
+						usedParameters,
+						usedResponses,
+						usedHeaders,
+					);
+					changed = true;
+				}
+			}
+		}
+	};
+
+	resolveAllRefs();
+
+	return {
+		openapi: fullSpec.openapi,
+		info: {
+			title: "GitHub REST API (Minimal)",
+			description: "Minimal subset of GitHub REST API for AnswerOverflow",
+			version: (fullSpec.info as Record<string, unknown>)?.version ?? "1.0.0",
+		},
+		servers: fullSpec.servers,
+		paths,
+		components: {
+			schemas,
+			parameters,
+			responses,
+			headers,
+			securitySchemes: fullComponents?.securitySchemes ?? {},
+		},
+	};
+};
+
+async function syncOpenApiSpec() {
+	console.log(`Fetching GitHub OpenAPI spec from ${GITHUB_OPENAPI_URL}...`);
+	console.log("(This is a large file ~15MB, may take a moment)");
+
+	try {
+		const response = await fetch(GITHUB_OPENAPI_URL);
+		if (!response.ok) {
+			throw new Error(
+				`Failed to fetch OpenAPI spec: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		const fullSpec = await response.json();
+		console.log("✅ Fetched full spec");
+
+		console.log("📦 Extracting minimal subset...");
+		const minimalSpec = extractMinimalSpec(fullSpec as Record<string, unknown>);
+
+		const specString = JSON.stringify(minimalSpec, null, 2);
+		console.log(
+			`📝 Minimal spec size: ${(specString.length / 1024).toFixed(1)}KB`,
+		);
+
+		await Bun.write(OUTPUT_FILE, specString);
+
+		console.log(`✅ Successfully updated ${OUTPUT_FILE}`);
+		console.log(
+			`📝 Next step: Run 'bun run gen' to regenerate the TypeScript types`,
+		);
+	} catch (error) {
+		console.error("❌ Error syncing OpenAPI spec:", error);
+		process.exit(1);
+	}
+}
+
+syncOpenApiSpec();

--- a/packages/github-api/src/generated.ts
+++ b/packages/github-api/src/generated.ts
@@ -1,0 +1,1884 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientError from "@effect/platform/HttpClientError";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import type { ParseError } from "effect/ParseResult";
+import * as S from "effect/Schema";
+
+export class AppsListInstallationsForAuthenticatedUserParams extends S.Struct({
+	per_page: S.optionalWith(S.Int, {
+		nullable: true,
+		default: () => 30 as const,
+	}),
+	page: S.optionalWith(S.Int, { nullable: true, default: () => 1 as const }),
+}) {}
+
+/**
+ * A GitHub user.
+ */
+export class SimpleUser extends S.Class<SimpleUser>("SimpleUser")({
+	name: S.optionalWith(S.String, { nullable: true }),
+	email: S.optionalWith(S.String, { nullable: true }),
+	login: S.String,
+	id: S.Int,
+	node_id: S.String,
+	avatar_url: S.String,
+	gravatar_id: S.NullOr(S.String),
+	url: S.String,
+	html_url: S.String,
+	followers_url: S.String,
+	following_url: S.String,
+	gists_url: S.String,
+	starred_url: S.String,
+	subscriptions_url: S.String,
+	organizations_url: S.String,
+	repos_url: S.String,
+	events_url: S.String,
+	received_events_url: S.String,
+	type: S.String,
+	site_admin: S.Boolean,
+	starred_at: S.optionalWith(S.String, { nullable: true }),
+	user_view_type: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+/**
+ * An enterprise on GitHub.
+ */
+export class Enterprise extends S.Class<Enterprise>("Enterprise")({
+	/**
+	 * A short description of the enterprise.
+	 */
+	description: S.optionalWith(S.String, { nullable: true }),
+	html_url: S.String,
+	/**
+	 * The enterprise's website URL.
+	 */
+	website_url: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * Unique identifier of the enterprise
+	 */
+	id: S.Int,
+	node_id: S.String,
+	/**
+	 * The name of the enterprise.
+	 */
+	name: S.String,
+	/**
+	 * The slug url identifier for the enterprise.
+	 */
+	slug: S.String,
+	created_at: S.NullOr(S.String),
+	updated_at: S.NullOr(S.String),
+	avatar_url: S.String,
+}) {}
+
+/**
+ * Describe whether all repositories have been selected or there's a selection involved
+ */
+export class InstallationRepositorySelection extends S.Literal(
+	"all",
+	"selected",
+) {}
+
+/**
+ * The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts.
+ */
+export class AppPermissionsActions extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for repository creation, deletion, settings, teams, and collaborators creation.
+ */
+export class AppPermissionsAdministration extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to create and retrieve build artifact metadata records.
+ */
+export class AppPermissionsArtifactMetadata extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to create and retrieve the access token for repository attestations.
+ */
+export class AppPermissionsAttestations extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for checks on code.
+ */
+export class AppPermissionsChecks extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to create, edit, delete, and list Codespaces.
+ */
+export class AppPermissionsCodespaces extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for repository contents, commits, branches, downloads, releases, and merges.
+ */
+export class AppPermissionsContents extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage Dependabot secrets.
+ */
+export class AppPermissionsDependabotSecrets extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for deployments and deployment statuses.
+ */
+export class AppPermissionsDeployments extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for discussions and related comments and labels.
+ */
+export class AppPermissionsDiscussions extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for managing repository environments.
+ */
+export class AppPermissionsEnvironments extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.
+ */
+export class AppPermissionsIssues extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage the merge queues for a repository.
+ */
+export class AppPermissionsMergeQueues extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.
+ */
+export class AppPermissionsMetadata extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for packages published to GitHub Packages.
+ */
+export class AppPermissionsPackages extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.
+ */
+export class AppPermissionsPages extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.
+ */
+export class AppPermissionsPullRequests extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to view and edit custom properties for a repository, when allowed by the property.
+ */
+export class AppPermissionsRepositoryCustomProperties extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to manage the post-receive hooks for a repository.
+ */
+export class AppPermissionsRepositoryHooks extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage repository projects, columns, and cards.
+ */
+export class AppPermissionsRepositoryProjects extends S.Literal(
+	"read",
+	"write",
+	"admin",
+) {}
+
+/**
+ * The level of permission to grant the access token to view and manage secret scanning alerts.
+ */
+export class AppPermissionsSecretScanningAlerts extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to manage repository secrets.
+ */
+export class AppPermissionsSecrets extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to view and manage security events like code scanning alerts.
+ */
+export class AppPermissionsSecurityEvents extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage just a single file.
+ */
+export class AppPermissionsSingleFile extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for commit statuses.
+ */
+export class AppPermissionsStatuses extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage Dependabot alerts.
+ */
+export class AppPermissionsVulnerabilityAlerts extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to update GitHub Actions workflow files.
+ */
+export class AppPermissionsWorkflows extends S.Literal("write") {}
+
+/**
+ * The level of permission to grant the access token to view and edit custom properties for an organization, when allowed by the property.
+ */
+export class AppPermissionsCustomPropertiesForOrganizations extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for organization teams and members.
+ */
+export class AppPermissionsMembers extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage access to an organization.
+ */
+export class AppPermissionsOrganizationAdministration extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for custom repository roles management.
+ */
+export class AppPermissionsOrganizationCustomRoles extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for custom organization roles management.
+ */
+export class AppPermissionsOrganizationCustomOrgRoles extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for repository custom properties management at the organization level.
+ */
+export class AppPermissionsOrganizationCustomProperties extends S.Literal(
+	"read",
+	"write",
+	"admin",
+) {}
+
+/**
+ * The level of permission to grant the access token for managing access to GitHub Copilot for members of an organization with a Copilot Business subscription. This property is in public preview and is subject to change.
+ */
+export class AppPermissionsOrganizationCopilotSeatManagement extends S.Literal(
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to view and manage announcement banners for an organization.
+ */
+export class AppPermissionsOrganizationAnnouncementBanners extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to view events triggered by an activity in an organization.
+ */
+export class AppPermissionsOrganizationEvents extends S.Literal("read") {}
+
+/**
+ * The level of permission to grant the access token to manage the post-receive hooks for an organization.
+ */
+export class AppPermissionsOrganizationHooks extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.
+ */
+export class AppPermissionsOrganizationPersonalAccessTokens extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.
+ */
+export class AppPermissionsOrganizationPersonalAccessTokenRequests extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token for viewing an organization's plan.
+ */
+export class AppPermissionsOrganizationPlan extends S.Literal("read") {}
+
+/**
+ * The level of permission to grant the access token to manage organization projects and projects public preview (where available).
+ */
+export class AppPermissionsOrganizationProjects extends S.Literal(
+	"read",
+	"write",
+	"admin",
+) {}
+
+/**
+ * The level of permission to grant the access token for organization packages published to GitHub Packages.
+ */
+export class AppPermissionsOrganizationPackages extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to manage organization secrets.
+ */
+export class AppPermissionsOrganizationSecrets extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.
+ */
+export class AppPermissionsOrganizationSelfHostedRunners extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to view and manage users blocked by the organization.
+ */
+export class AppPermissionsOrganizationUserBlocking extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to manage team discussions and related comments.
+ */
+export class AppPermissionsTeamDiscussions extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage the email addresses belonging to a user.
+ */
+export class AppPermissionsEmailAddresses extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage the followers belonging to a user.
+ */
+export class AppPermissionsFollowers extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to manage git SSH keys.
+ */
+export class AppPermissionsGitSshKeys extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to view and manage GPG keys belonging to a user.
+ */
+export class AppPermissionsGpgKeys extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token to view and manage interaction limits on a repository.
+ */
+export class AppPermissionsInteractionLimits extends S.Literal(
+	"read",
+	"write",
+) {}
+
+/**
+ * The level of permission to grant the access token to manage the profile settings belonging to a user.
+ */
+export class AppPermissionsProfile extends S.Literal("write") {}
+
+/**
+ * The level of permission to grant the access token to list and manage repositories a user is starring.
+ */
+export class AppPermissionsStarring extends S.Literal("read", "write") {}
+
+/**
+ * The level of permission to grant the access token for organization custom properties management at the enterprise level.
+ */
+export class AppPermissionsEnterpriseCustomPropertiesForOrganizations extends S.Literal(
+	"read",
+	"write",
+	"admin",
+) {}
+
+/**
+ * The permissions granted to the user access token.
+ */
+export class AppPermissions extends S.Class<AppPermissions>("AppPermissions")({
+	/**
+	 * The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts.
+	 */
+	actions: S.optionalWith(AppPermissionsActions, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for repository creation, deletion, settings, teams, and collaborators creation.
+	 */
+	administration: S.optionalWith(AppPermissionsAdministration, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to create and retrieve build artifact metadata records.
+	 */
+	artifact_metadata: S.optionalWith(AppPermissionsArtifactMetadata, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to create and retrieve the access token for repository attestations.
+	 */
+	attestations: S.optionalWith(AppPermissionsAttestations, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for checks on code.
+	 */
+	checks: S.optionalWith(AppPermissionsChecks, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to create, edit, delete, and list Codespaces.
+	 */
+	codespaces: S.optionalWith(AppPermissionsCodespaces, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for repository contents, commits, branches, downloads, releases, and merges.
+	 */
+	contents: S.optionalWith(AppPermissionsContents, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to manage Dependabot secrets.
+	 */
+	dependabot_secrets: S.optionalWith(AppPermissionsDependabotSecrets, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token for deployments and deployment statuses.
+	 */
+	deployments: S.optionalWith(AppPermissionsDeployments, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for discussions and related comments and labels.
+	 */
+	discussions: S.optionalWith(AppPermissionsDiscussions, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for managing repository environments.
+	 */
+	environments: S.optionalWith(AppPermissionsEnvironments, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.
+	 */
+	issues: S.optionalWith(AppPermissionsIssues, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to manage the merge queues for a repository.
+	 */
+	merge_queues: S.optionalWith(AppPermissionsMergeQueues, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.
+	 */
+	metadata: S.optionalWith(AppPermissionsMetadata, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for packages published to GitHub Packages.
+	 */
+	packages: S.optionalWith(AppPermissionsPackages, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.
+	 */
+	pages: S.optionalWith(AppPermissionsPages, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.
+	 */
+	pull_requests: S.optionalWith(AppPermissionsPullRequests, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to view and edit custom properties for a repository, when allowed by the property.
+	 */
+	repository_custom_properties: S.optionalWith(
+		AppPermissionsRepositoryCustomProperties,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token to manage the post-receive hooks for a repository.
+	 */
+	repository_hooks: S.optionalWith(AppPermissionsRepositoryHooks, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage repository projects, columns, and cards.
+	 */
+	repository_projects: S.optionalWith(AppPermissionsRepositoryProjects, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to view and manage secret scanning alerts.
+	 */
+	secret_scanning_alerts: S.optionalWith(AppPermissionsSecretScanningAlerts, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage repository secrets.
+	 */
+	secrets: S.optionalWith(AppPermissionsSecrets, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to view and manage security events like code scanning alerts.
+	 */
+	security_events: S.optionalWith(AppPermissionsSecurityEvents, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage just a single file.
+	 */
+	single_file: S.optionalWith(AppPermissionsSingleFile, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for commit statuses.
+	 */
+	statuses: S.optionalWith(AppPermissionsStatuses, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to manage Dependabot alerts.
+	 */
+	vulnerability_alerts: S.optionalWith(AppPermissionsVulnerabilityAlerts, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to update GitHub Actions workflow files.
+	 */
+	workflows: S.optionalWith(AppPermissionsWorkflows, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to view and edit custom properties for an organization, when allowed by the property.
+	 */
+	custom_properties_for_organizations: S.optionalWith(
+		AppPermissionsCustomPropertiesForOrganizations,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for organization teams and members.
+	 */
+	members: S.optionalWith(AppPermissionsMembers, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to manage access to an organization.
+	 */
+	organization_administration: S.optionalWith(
+		AppPermissionsOrganizationAdministration,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for custom repository roles management.
+	 */
+	organization_custom_roles: S.optionalWith(
+		AppPermissionsOrganizationCustomRoles,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for custom organization roles management.
+	 */
+	organization_custom_org_roles: S.optionalWith(
+		AppPermissionsOrganizationCustomOrgRoles,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for repository custom properties management at the organization level.
+	 */
+	organization_custom_properties: S.optionalWith(
+		AppPermissionsOrganizationCustomProperties,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for managing access to GitHub Copilot for members of an organization with a Copilot Business subscription. This property is in public preview and is subject to change.
+	 */
+	organization_copilot_seat_management: S.optionalWith(
+		AppPermissionsOrganizationCopilotSeatManagement,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token to view and manage announcement banners for an organization.
+	 */
+	organization_announcement_banners: S.optionalWith(
+		AppPermissionsOrganizationAnnouncementBanners,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token to view events triggered by an activity in an organization.
+	 */
+	organization_events: S.optionalWith(AppPermissionsOrganizationEvents, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage the post-receive hooks for an organization.
+	 */
+	organization_hooks: S.optionalWith(AppPermissionsOrganizationHooks, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.
+	 */
+	organization_personal_access_tokens: S.optionalWith(
+		AppPermissionsOrganizationPersonalAccessTokens,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.
+	 */
+	organization_personal_access_token_requests: S.optionalWith(
+		AppPermissionsOrganizationPersonalAccessTokenRequests,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token for viewing an organization's plan.
+	 */
+	organization_plan: S.optionalWith(AppPermissionsOrganizationPlan, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage organization projects and projects public preview (where available).
+	 */
+	organization_projects: S.optionalWith(AppPermissionsOrganizationProjects, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token for organization packages published to GitHub Packages.
+	 */
+	organization_packages: S.optionalWith(AppPermissionsOrganizationPackages, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage organization secrets.
+	 */
+	organization_secrets: S.optionalWith(AppPermissionsOrganizationSecrets, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.
+	 */
+	organization_self_hosted_runners: S.optionalWith(
+		AppPermissionsOrganizationSelfHostedRunners,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token to view and manage users blocked by the organization.
+	 */
+	organization_user_blocking: S.optionalWith(
+		AppPermissionsOrganizationUserBlocking,
+		{ nullable: true },
+	),
+	/**
+	 * The level of permission to grant the access token to manage team discussions and related comments.
+	 */
+	team_discussions: S.optionalWith(AppPermissionsTeamDiscussions, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage the email addresses belonging to a user.
+	 */
+	email_addresses: S.optionalWith(AppPermissionsEmailAddresses, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage the followers belonging to a user.
+	 */
+	followers: S.optionalWith(AppPermissionsFollowers, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to manage git SSH keys.
+	 */
+	git_ssh_keys: S.optionalWith(AppPermissionsGitSshKeys, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to view and manage GPG keys belonging to a user.
+	 */
+	gpg_keys: S.optionalWith(AppPermissionsGpgKeys, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to view and manage interaction limits on a repository.
+	 */
+	interaction_limits: S.optionalWith(AppPermissionsInteractionLimits, {
+		nullable: true,
+	}),
+	/**
+	 * The level of permission to grant the access token to manage the profile settings belonging to a user.
+	 */
+	profile: S.optionalWith(AppPermissionsProfile, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token to list and manage repositories a user is starring.
+	 */
+	starring: S.optionalWith(AppPermissionsStarring, { nullable: true }),
+	/**
+	 * The level of permission to grant the access token for organization custom properties management at the enterprise level.
+	 */
+	enterprise_custom_properties_for_organizations: S.optionalWith(
+		AppPermissionsEnterpriseCustomPropertiesForOrganizations,
+		{ nullable: true },
+	),
+}) {}
+
+/**
+ * A GitHub user.
+ */
+export class NullableSimpleUser extends S.Class<NullableSimpleUser>(
+	"NullableSimpleUser",
+)({
+	name: S.optionalWith(S.String, { nullable: true }),
+	email: S.optionalWith(S.String, { nullable: true }),
+	login: S.String,
+	id: S.Int,
+	node_id: S.String,
+	avatar_url: S.String,
+	gravatar_id: S.NullOr(S.String),
+	url: S.String,
+	html_url: S.String,
+	followers_url: S.String,
+	following_url: S.String,
+	gists_url: S.String,
+	starred_url: S.String,
+	subscriptions_url: S.String,
+	organizations_url: S.String,
+	repos_url: S.String,
+	events_url: S.String,
+	received_events_url: S.String,
+	type: S.String,
+	site_admin: S.Boolean,
+	starred_at: S.optionalWith(S.String, { nullable: true }),
+	user_view_type: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+/**
+ * Installation
+ */
+export class Installation extends S.Class<Installation>("Installation")({
+	/**
+	 * The ID of the installation.
+	 */
+	id: S.Int,
+	account: S.NullOr(S.Union(SimpleUser, Enterprise)),
+	/**
+	 * Describe whether all repositories have been selected or there's a selection involved
+	 */
+	repository_selection: InstallationRepositorySelection,
+	access_tokens_url: S.String,
+	repositories_url: S.String,
+	html_url: S.String,
+	app_id: S.Int,
+	client_id: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * The ID of the user or organization this token is being scoped to.
+	 */
+	target_id: S.Int,
+	target_type: S.String,
+	permissions: AppPermissions,
+	events: S.Array(S.String),
+	created_at: S.String,
+	updated_at: S.String,
+	single_file_name: S.NullOr(S.String),
+	has_multiple_single_files: S.optionalWith(S.Boolean, { nullable: true }),
+	single_file_paths: S.optionalWith(S.Array(S.String), { nullable: true }),
+	app_slug: S.String,
+	suspended_by: S.NullOr(NullableSimpleUser),
+	suspended_at: S.NullOr(S.String),
+	contact_email: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+export class AppsListInstallationsForAuthenticatedUser200 extends S.Struct({
+	total_count: S.Int,
+	installations: S.Array(Installation),
+}) {}
+
+/**
+ * Basic Error
+ */
+export class BasicError extends S.Class<BasicError>("BasicError")({
+	message: S.optionalWith(S.String, { nullable: true }),
+	documentation_url: S.optionalWith(S.String, { nullable: true }),
+	url: S.optionalWith(S.String, { nullable: true }),
+	status: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+export class AppsListInstallationReposForAuthenticatedUserParams extends S.Struct(
+	{
+		per_page: S.optionalWith(S.Int, {
+			nullable: true,
+			default: () => 30 as const,
+		}),
+		page: S.optionalWith(S.Int, { nullable: true, default: () => 1 as const }),
+	},
+) {}
+
+/**
+ * License Simple
+ */
+export class NullableLicenseSimple extends S.Class<NullableLicenseSimple>(
+	"NullableLicenseSimple",
+)({
+	key: S.String,
+	name: S.String,
+	url: S.NullOr(S.String),
+	spdx_id: S.NullOr(S.String),
+	node_id: S.String,
+	html_url: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+/**
+ * The default value for a squash merge commit title:
+ *
+ * - `PR_TITLE` - default to the pull request's title.
+ * - `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).
+ */
+export class RepositorySquashMergeCommitTitle extends S.Literal(
+	"PR_TITLE",
+	"COMMIT_OR_PR_TITLE",
+) {}
+
+/**
+ * The default value for a squash merge commit message:
+ *
+ * - `PR_BODY` - default to the pull request's body.
+ * - `COMMIT_MESSAGES` - default to the branch's commit messages.
+ * - `BLANK` - default to a blank commit message.
+ */
+export class RepositorySquashMergeCommitMessage extends S.Literal(
+	"PR_BODY",
+	"COMMIT_MESSAGES",
+	"BLANK",
+) {}
+
+/**
+ * The default value for a merge commit title.
+ *
+ * - `PR_TITLE` - default to the pull request's title.
+ * - `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).
+ */
+export class RepositoryMergeCommitTitle extends S.Literal(
+	"PR_TITLE",
+	"MERGE_MESSAGE",
+) {}
+
+/**
+ * The default value for a merge commit message.
+ *
+ * - `PR_TITLE` - default to the pull request's title.
+ * - `PR_BODY` - default to the pull request's body.
+ * - `BLANK` - default to a blank commit message.
+ */
+export class RepositoryMergeCommitMessage extends S.Literal(
+	"PR_BODY",
+	"PR_TITLE",
+	"BLANK",
+) {}
+
+/**
+ * A repository on GitHub.
+ */
+export class Repository extends S.Class<Repository>("Repository")({
+	/**
+	 * Unique identifier of the repository
+	 */
+	id: S.Int,
+	node_id: S.String,
+	/**
+	 * The name of the repository.
+	 */
+	name: S.String,
+	full_name: S.String,
+	license: S.NullOr(NullableLicenseSimple),
+	forks: S.Int,
+	permissions: S.optionalWith(
+		S.Struct({
+			admin: S.Boolean,
+			pull: S.Boolean,
+			triage: S.optionalWith(S.Boolean, { nullable: true }),
+			push: S.Boolean,
+			maintain: S.optionalWith(S.Boolean, { nullable: true }),
+		}),
+		{ nullable: true },
+	),
+	owner: SimpleUser,
+	/**
+	 * Whether the repository is private or public.
+	 */
+	private: S.Boolean.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => false as const),
+	),
+	html_url: S.String,
+	description: S.NullOr(S.String),
+	fork: S.Boolean,
+	url: S.String,
+	archive_url: S.String,
+	assignees_url: S.String,
+	blobs_url: S.String,
+	branches_url: S.String,
+	collaborators_url: S.String,
+	comments_url: S.String,
+	commits_url: S.String,
+	compare_url: S.String,
+	contents_url: S.String,
+	contributors_url: S.String,
+	deployments_url: S.String,
+	downloads_url: S.String,
+	events_url: S.String,
+	forks_url: S.String,
+	git_commits_url: S.String,
+	git_refs_url: S.String,
+	git_tags_url: S.String,
+	git_url: S.String,
+	issue_comment_url: S.String,
+	issue_events_url: S.String,
+	issues_url: S.String,
+	keys_url: S.String,
+	labels_url: S.String,
+	languages_url: S.String,
+	merges_url: S.String,
+	milestones_url: S.String,
+	notifications_url: S.String,
+	pulls_url: S.String,
+	releases_url: S.String,
+	ssh_url: S.String,
+	stargazers_url: S.String,
+	statuses_url: S.String,
+	subscribers_url: S.String,
+	subscription_url: S.String,
+	tags_url: S.String,
+	teams_url: S.String,
+	trees_url: S.String,
+	clone_url: S.String,
+	mirror_url: S.NullOr(S.String),
+	hooks_url: S.String,
+	svn_url: S.String,
+	homepage: S.NullOr(S.String),
+	language: S.NullOr(S.String),
+	forks_count: S.Int,
+	stargazers_count: S.Int,
+	watchers_count: S.Int,
+	/**
+	 * The size of the repository, in kilobytes. Size is calculated hourly. When a repository is initially created, the size is 0.
+	 */
+	size: S.Int,
+	/**
+	 * The default branch of the repository.
+	 */
+	default_branch: S.String,
+	open_issues_count: S.Int,
+	/**
+	 * Whether this repository acts as a template that can be used to generate new repositories.
+	 */
+	is_template: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	topics: S.optionalWith(S.Array(S.String), { nullable: true }),
+	/**
+	 * Whether issues are enabled.
+	 */
+	has_issues: S.Boolean.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => true as const),
+	),
+	/**
+	 * Whether projects are enabled.
+	 */
+	has_projects: S.Boolean.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => true as const),
+	),
+	/**
+	 * Whether the wiki is enabled.
+	 */
+	has_wiki: S.Boolean.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => true as const),
+	),
+	has_pages: S.Boolean,
+	/**
+	 * Whether downloads are enabled.
+	 */
+	has_downloads: S.Boolean.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => true as const),
+	),
+	/**
+	 * Whether discussions are enabled.
+	 */
+	has_discussions: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	/**
+	 * Whether the repository is archived.
+	 */
+	archived: S.Boolean.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => false as const),
+	),
+	/**
+	 * Returns whether or not this repository disabled.
+	 */
+	disabled: S.Boolean,
+	/**
+	 * The repository visibility: public, private, or internal.
+	 */
+	visibility: S.optionalWith(S.String, {
+		nullable: true,
+		default: () => "public" as const,
+	}),
+	pushed_at: S.NullOr(S.String),
+	created_at: S.NullOr(S.String),
+	updated_at: S.NullOr(S.String),
+	/**
+	 * Whether to allow rebase merges for pull requests.
+	 */
+	allow_rebase_merge: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => true as const,
+	}),
+	temp_clone_token: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * Whether to allow squash merges for pull requests.
+	 */
+	allow_squash_merge: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => true as const,
+	}),
+	/**
+	 * Whether to allow Auto-merge to be used on pull requests.
+	 */
+	allow_auto_merge: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	/**
+	 * Whether to delete head branches when pull requests are merged
+	 */
+	delete_branch_on_merge: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	/**
+	 * Whether or not a pull request head branch that is behind its base branch can always be updated even if it is not required to be up to date before merging.
+	 */
+	allow_update_branch: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	/**
+	 * Whether a squash merge commit can use the pull request title as default. **This property is closing down. Please use `squash_merge_commit_title` instead.
+	 */
+	use_squash_pr_title_as_default: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	/**
+	 * The default value for a squash merge commit title:
+	 *
+	 * - `PR_TITLE` - default to the pull request's title.
+	 * - `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).
+	 */
+	squash_merge_commit_title: S.optionalWith(RepositorySquashMergeCommitTitle, {
+		nullable: true,
+	}),
+	/**
+	 * The default value for a squash merge commit message:
+	 *
+	 * - `PR_BODY` - default to the pull request's body.
+	 * - `COMMIT_MESSAGES` - default to the branch's commit messages.
+	 * - `BLANK` - default to a blank commit message.
+	 */
+	squash_merge_commit_message: S.optionalWith(
+		RepositorySquashMergeCommitMessage,
+		{ nullable: true },
+	),
+	/**
+	 * The default value for a merge commit title.
+	 *
+	 * - `PR_TITLE` - default to the pull request's title.
+	 * - `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).
+	 */
+	merge_commit_title: S.optionalWith(RepositoryMergeCommitTitle, {
+		nullable: true,
+	}),
+	/**
+	 * The default value for a merge commit message.
+	 *
+	 * - `PR_TITLE` - default to the pull request's title.
+	 * - `PR_BODY` - default to the pull request's body.
+	 * - `BLANK` - default to a blank commit message.
+	 */
+	merge_commit_message: S.optionalWith(RepositoryMergeCommitMessage, {
+		nullable: true,
+	}),
+	/**
+	 * Whether to allow merge commits for pull requests.
+	 */
+	allow_merge_commit: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => true as const,
+	}),
+	/**
+	 * Whether to allow forking this repo
+	 */
+	allow_forking: S.optionalWith(S.Boolean, { nullable: true }),
+	/**
+	 * Whether to require contributors to sign off on web-based commits
+	 */
+	web_commit_signoff_required: S.optionalWith(S.Boolean, {
+		nullable: true,
+		default: () => false as const,
+	}),
+	open_issues: S.Int,
+	watchers: S.Int,
+	master_branch: S.optionalWith(S.String, { nullable: true }),
+	starred_at: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * Whether anonymous git access is enabled for this repository
+	 */
+	anonymous_access_enabled: S.optionalWith(S.Boolean, { nullable: true }),
+	/**
+	 * The status of the code search index for this repository
+	 */
+	code_search_index_status: S.optionalWith(
+		S.Struct({
+			lexical_search_ok: S.optionalWith(S.Boolean, { nullable: true }),
+			lexical_commit_sha: S.optionalWith(S.String, { nullable: true }),
+		}),
+		{ nullable: true },
+	),
+}) {}
+
+export class AppsListInstallationReposForAuthenticatedUser200 extends S.Struct({
+	total_count: S.Int,
+	repository_selection: S.optionalWith(S.String, { nullable: true }),
+	repositories: S.Array(Repository),
+}) {}
+
+export class IssuesListForRepoParamsState extends S.Literal(
+	"open",
+	"closed",
+	"all",
+) {}
+
+export class IssuesListForRepoParamsSort extends S.Literal(
+	"created",
+	"updated",
+	"comments",
+) {}
+
+export class IssuesListForRepoParamsDirection extends S.Literal(
+	"asc",
+	"desc",
+) {}
+
+export class IssuesListForRepoParams extends S.Struct({
+	milestone: S.optionalWith(S.String, { nullable: true }),
+	state: S.optionalWith(IssuesListForRepoParamsState, {
+		nullable: true,
+		default: () => "open" as const,
+	}),
+	assignee: S.optionalWith(S.String, { nullable: true }),
+	type: S.optionalWith(S.String, { nullable: true }),
+	creator: S.optionalWith(S.String, { nullable: true }),
+	mentioned: S.optionalWith(S.String, { nullable: true }),
+	labels: S.optionalWith(S.String, { nullable: true }),
+	sort: S.optionalWith(IssuesListForRepoParamsSort, {
+		nullable: true,
+		default: () => "created" as const,
+	}),
+	direction: S.optionalWith(IssuesListForRepoParamsDirection, {
+		nullable: true,
+		default: () => "desc" as const,
+	}),
+	since: S.optionalWith(S.String, { nullable: true }),
+	per_page: S.optionalWith(S.Int, {
+		nullable: true,
+		default: () => 30 as const,
+	}),
+	page: S.optionalWith(S.Int, { nullable: true, default: () => 1 as const }),
+}) {}
+
+/**
+ * The reason for the current state
+ */
+export class IssueStateReason extends S.Literal(
+	"completed",
+	"reopened",
+	"not_planned",
+	"duplicate",
+) {}
+
+/**
+ * The state of the milestone.
+ */
+export class NullableMilestoneState extends S.Literal("open", "closed") {}
+
+/**
+ * A collection of related issues and pull requests.
+ */
+export class NullableMilestone extends S.Class<NullableMilestone>(
+	"NullableMilestone",
+)({
+	url: S.String,
+	html_url: S.String,
+	labels_url: S.String,
+	id: S.Int,
+	node_id: S.String,
+	/**
+	 * The number of the milestone.
+	 */
+	number: S.Int,
+	/**
+	 * The state of the milestone.
+	 */
+	state: NullableMilestoneState.pipe(
+		S.propertySignature,
+		S.withConstructorDefault(() => "open" as const),
+	),
+	/**
+	 * The title of the milestone.
+	 */
+	title: S.String,
+	description: S.NullOr(S.String),
+	creator: S.NullOr(NullableSimpleUser),
+	open_issues: S.Int,
+	closed_issues: S.Int,
+	created_at: S.String,
+	updated_at: S.String,
+	closed_at: S.NullOr(S.String),
+	due_on: S.NullOr(S.String),
+}) {}
+
+/**
+ * The color of the issue type.
+ */
+export class IssueTypeColor extends S.Literal(
+	"gray",
+	"blue",
+	"green",
+	"yellow",
+	"orange",
+	"red",
+	"pink",
+	"purple",
+) {}
+
+/**
+ * The type of issue.
+ */
+export class IssueType extends S.Class<IssueType>("IssueType")({
+	/**
+	 * The unique identifier of the issue type.
+	 */
+	id: S.Int,
+	/**
+	 * The node identifier of the issue type.
+	 */
+	node_id: S.String,
+	/**
+	 * The name of the issue type.
+	 */
+	name: S.String,
+	/**
+	 * The description of the issue type.
+	 */
+	description: S.NullOr(S.String),
+	/**
+	 * The color of the issue type.
+	 */
+	color: S.optionalWith(IssueTypeColor, { nullable: true }),
+	/**
+	 * The time the issue type created.
+	 */
+	created_at: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * The time the issue type last updated.
+	 */
+	updated_at: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * The enabled state of the issue type.
+	 */
+	is_enabled: S.optionalWith(S.Boolean, { nullable: true }),
+}) {}
+
+/**
+ * GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub.
+ */
+export class NullableIntegration extends S.Class<NullableIntegration>(
+	"NullableIntegration",
+)({
+	/**
+	 * Unique identifier of the GitHub app
+	 */
+	id: S.Int,
+	/**
+	 * The slug name of the GitHub app
+	 */
+	slug: S.optionalWith(S.String, { nullable: true }),
+	node_id: S.String,
+	client_id: S.optionalWith(S.String, { nullable: true }),
+	owner: S.Union(SimpleUser, Enterprise),
+	/**
+	 * The name of the GitHub app
+	 */
+	name: S.String,
+	description: S.NullOr(S.String),
+	external_url: S.String,
+	html_url: S.String,
+	created_at: S.String,
+	updated_at: S.String,
+	/**
+	 * The set of permissions for the GitHub app
+	 */
+	permissions: S.Struct({
+		issues: S.optionalWith(S.String, { nullable: true }),
+		checks: S.optionalWith(S.String, { nullable: true }),
+		metadata: S.optionalWith(S.String, { nullable: true }),
+		contents: S.optionalWith(S.String, { nullable: true }),
+		deployments: S.optionalWith(S.String, { nullable: true }),
+	}),
+	/**
+	 * The list of events for the GitHub app. Note that the `installation_target`, `security_advisory`, and `meta` events are not included because they are global events and not specific to an installation.
+	 */
+	events: S.Array(S.String),
+	/**
+	 * The number of installations associated with the GitHub app. Only returned when the integration is requesting details about itself.
+	 */
+	installations_count: S.optionalWith(S.Int, { nullable: true }),
+}) {}
+
+/**
+ * How the author is associated with the repository.
+ */
+export class AuthorAssociation extends S.Literal(
+	"COLLABORATOR",
+	"CONTRIBUTOR",
+	"FIRST_TIMER",
+	"FIRST_TIME_CONTRIBUTOR",
+	"MANNEQUIN",
+	"MEMBER",
+	"NONE",
+	"OWNER",
+) {}
+
+export class ReactionRollup extends S.Class<ReactionRollup>("ReactionRollup")({
+	url: S.String,
+	total_count: S.Int,
+	"+1": S.Int,
+	"-1": S.Int,
+	laugh: S.Int,
+	confused: S.Int,
+	heart: S.Int,
+	hooray: S.Int,
+	eyes: S.Int,
+	rocket: S.Int,
+}) {}
+
+export class SubIssuesSummary extends S.Class<SubIssuesSummary>(
+	"SubIssuesSummary",
+)({
+	total: S.Int,
+	completed: S.Int,
+	percent_completed: S.Int,
+}) {}
+
+export class IssueDependenciesSummary extends S.Class<IssueDependenciesSummary>(
+	"IssueDependenciesSummary",
+)({
+	blocked_by: S.Int,
+	blocking: S.Int,
+	total_blocked_by: S.Int,
+	total_blocking: S.Int,
+}) {}
+
+/**
+ * The data type of the issue field
+ */
+export class IssueFieldValueDataType extends S.Literal(
+	"text",
+	"single_select",
+	"number",
+	"date",
+) {}
+
+/**
+ * A value assigned to an issue field
+ */
+export class IssueFieldValue extends S.Class<IssueFieldValue>(
+	"IssueFieldValue",
+)({
+	/**
+	 * Unique identifier for the issue field.
+	 */
+	issue_field_id: S.Int,
+	node_id: S.String,
+	/**
+	 * The data type of the issue field
+	 */
+	data_type: IssueFieldValueDataType,
+	/**
+	 * The value of the issue field
+	 */
+	value: S.NullOr(S.Union(S.String, S.Number, S.Int)),
+	/**
+	 * Details about the selected option (only present for single_select fields)
+	 */
+	single_select_option: S.optionalWith(
+		S.Struct({
+			/**
+			 * Unique identifier for the option.
+			 */
+			id: S.Int,
+			/**
+			 * The name of the option
+			 */
+			name: S.String,
+			/**
+			 * The color of the option
+			 */
+			color: S.String,
+		}),
+		{ nullable: true },
+	),
+}) {}
+
+/**
+ * Issues are a great way to keep track of tasks, enhancements, and bugs for your projects.
+ */
+export class Issue extends S.Class<Issue>("Issue")({
+	id: S.Int,
+	node_id: S.String,
+	/**
+	 * URL for the issue
+	 */
+	url: S.String,
+	repository_url: S.String,
+	labels_url: S.String,
+	comments_url: S.String,
+	events_url: S.String,
+	html_url: S.String,
+	/**
+	 * Number uniquely identifying the issue within its repository
+	 */
+	number: S.Int,
+	/**
+	 * State of the issue; either 'open' or 'closed'
+	 */
+	state: S.String,
+	/**
+	 * The reason for the current state
+	 */
+	state_reason: S.optionalWith(IssueStateReason, { nullable: true }),
+	/**
+	 * Title of the issue
+	 */
+	title: S.String,
+	/**
+	 * Contents of the issue
+	 */
+	body: S.optionalWith(S.String, { nullable: true }),
+	user: S.NullOr(NullableSimpleUser),
+	/**
+	 * Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
+	 */
+	labels: S.Array(
+		S.Union(
+			S.String,
+			S.Struct({
+				id: S.optionalWith(S.Int, { nullable: true }),
+				node_id: S.optionalWith(S.String, { nullable: true }),
+				url: S.optionalWith(S.String, { nullable: true }),
+				name: S.optionalWith(S.String, { nullable: true }),
+				description: S.optionalWith(S.String, { nullable: true }),
+				color: S.optionalWith(S.String, { nullable: true }),
+				default: S.optionalWith(S.Boolean, { nullable: true }),
+			}),
+		),
+	),
+	assignee: S.NullOr(NullableSimpleUser),
+	assignees: S.optionalWith(S.Array(SimpleUser), { nullable: true }),
+	milestone: S.NullOr(NullableMilestone),
+	locked: S.Boolean,
+	active_lock_reason: S.optionalWith(S.String, { nullable: true }),
+	comments: S.Int,
+	pull_request: S.optionalWith(
+		S.Struct({
+			merged_at: S.optionalWith(S.String, { nullable: true }),
+			diff_url: S.NullOr(S.String),
+			html_url: S.NullOr(S.String),
+			patch_url: S.NullOr(S.String),
+			url: S.NullOr(S.String),
+		}),
+		{ nullable: true },
+	),
+	closed_at: S.NullOr(S.String),
+	created_at: S.String,
+	updated_at: S.String,
+	draft: S.optionalWith(S.Boolean, { nullable: true }),
+	closed_by: S.optionalWith(NullableSimpleUser, { nullable: true }),
+	body_html: S.optionalWith(S.String, { nullable: true }),
+	body_text: S.optionalWith(S.String, { nullable: true }),
+	timeline_url: S.optionalWith(S.String, { nullable: true }),
+	type: S.optionalWith(IssueType, { nullable: true }),
+	repository: S.optionalWith(Repository, { nullable: true }),
+	performed_via_github_app: S.optionalWith(NullableIntegration, {
+		nullable: true,
+	}),
+	author_association: S.optionalWith(AuthorAssociation, { nullable: true }),
+	reactions: S.optionalWith(ReactionRollup, { nullable: true }),
+	sub_issues_summary: S.optionalWith(SubIssuesSummary, { nullable: true }),
+	/**
+	 * URL to get the parent issue of this issue, if it is a sub-issue
+	 */
+	parent_issue_url: S.optionalWith(S.String, { nullable: true }),
+	issue_dependencies_summary: S.optionalWith(IssueDependenciesSummary, {
+		nullable: true,
+	}),
+	issue_field_values: S.optionalWith(S.Array(IssueFieldValue), {
+		nullable: true,
+	}),
+}) {}
+
+export class IssuesListForRepo200 extends S.Array(Issue) {}
+
+/**
+ * Validation Error
+ */
+export class ValidationError extends S.Class<ValidationError>(
+	"ValidationError",
+)({
+	message: S.String,
+	documentation_url: S.String,
+	errors: S.optionalWith(
+		S.Array(
+			S.Struct({
+				resource: S.optionalWith(S.String, { nullable: true }),
+				field: S.optionalWith(S.String, { nullable: true }),
+				message: S.optionalWith(S.String, { nullable: true }),
+				code: S.String,
+				index: S.optionalWith(S.Int, { nullable: true }),
+				value: S.optionalWith(S.Union(S.String, S.Int, S.Array(S.String)), {
+					nullable: true,
+				}),
+			}),
+		),
+		{ nullable: true },
+	),
+}) {}
+
+export class IssuesCreateParams extends S.Struct({}) {}
+
+export class IssuesCreateRequest extends S.Class<IssuesCreateRequest>(
+	"IssuesCreateRequest",
+)({
+	/**
+	 * The title of the issue.
+	 */
+	title: S.Union(S.String, S.Int),
+	/**
+	 * The contents of the issue.
+	 */
+	body: S.optionalWith(S.String, { nullable: true }),
+	/**
+	 * Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is closing down.**_
+	 */
+	assignee: S.optionalWith(S.String, { nullable: true }),
+	milestone: S.optionalWith(
+		S.Union(
+			S.String,
+			/**
+			 * The `number` of the milestone to associate this issue with. _NOTE: Only users with push access can set the milestone for new issues. The milestone is silently dropped otherwise._
+			 */
+			S.Int,
+		),
+		{ nullable: true },
+	),
+	/**
+	 * Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._
+	 */
+	labels: S.optionalWith(
+		S.Array(
+			S.Union(
+				S.String,
+				S.Struct({
+					id: S.optionalWith(S.Int, { nullable: true }),
+					name: S.optionalWith(S.String, { nullable: true }),
+					description: S.optionalWith(S.String, { nullable: true }),
+					color: S.optionalWith(S.String, { nullable: true }),
+				}),
+			),
+		),
+		{ nullable: true },
+	),
+	/**
+	 * Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._
+	 */
+	assignees: S.optionalWith(S.Array(S.String), { nullable: true }),
+	/**
+	 * The name of the issue type to associate with this issue. _NOTE: Only users with push access can set the type for new issues. The type is silently dropped otherwise._
+	 */
+	type: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+export class IssuesCreate503 extends S.Struct({
+	code: S.optionalWith(S.String, { nullable: true }),
+	message: S.optionalWith(S.String, { nullable: true }),
+	documentation_url: S.optionalWith(S.String, { nullable: true }),
+}) {}
+
+export const make = (
+	httpClient: HttpClient.HttpClient,
+	options: {
+		readonly transformClient?:
+			| ((
+					client: HttpClient.HttpClient,
+			  ) => Effect.Effect<HttpClient.HttpClient>)
+			| undefined;
+	} = {},
+): Client => {
+	const unexpectedStatus = (response: HttpClientResponse.HttpClientResponse) =>
+		Effect.flatMap(
+			Effect.orElseSucceed(response.json, () => "Unexpected status code"),
+			(description) =>
+				Effect.fail(
+					new HttpClientError.ResponseError({
+						request: response.request,
+						response,
+						reason: "StatusCode",
+						description:
+							typeof description === "string"
+								? description
+								: JSON.stringify(description),
+					}),
+				),
+		);
+	const withResponse: <A, E>(
+		f: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<A, E>,
+	) => (
+		request: HttpClientRequest.HttpClientRequest,
+	) => Effect.Effect<any, any> = options.transformClient
+		? (f) => (request) =>
+				Effect.flatMap(
+					Effect.flatMap(options.transformClient!(httpClient), (client) =>
+						client.execute(request),
+					),
+					f,
+				)
+		: (f) => (request) => Effect.flatMap(httpClient.execute(request), f);
+	const decodeSuccess =
+		<A, I, R>(schema: S.Schema<A, I, R>) =>
+		(response: HttpClientResponse.HttpClientResponse) =>
+			HttpClientResponse.schemaBodyJson(schema)(response);
+	const decodeError =
+		<const Tag extends string, A, I, R>(tag: Tag, schema: S.Schema<A, I, R>) =>
+		(response: HttpClientResponse.HttpClientResponse) =>
+			Effect.flatMap(
+				HttpClientResponse.schemaBodyJson(schema)(response),
+				(cause) => Effect.fail(ClientError(tag, cause, response)),
+			);
+	return {
+		httpClient,
+		appsListInstallationsForAuthenticatedUser: (options) =>
+			HttpClientRequest.get(`/user/installations`).pipe(
+				HttpClientRequest.setUrlParams({
+					per_page: options?.["per_page"] as any,
+					page: options?.["page"] as any,
+				}),
+				withResponse(
+					HttpClientResponse.matchStatus({
+						"2xx": decodeSuccess(AppsListInstallationsForAuthenticatedUser200),
+						"401": decodeError("BasicError", BasicError),
+						"403": decodeError("BasicError", BasicError),
+						"304": () => Effect.void,
+						orElse: unexpectedStatus,
+					}),
+				),
+			),
+		appsListInstallationReposForAuthenticatedUser: (installationId, options) =>
+			HttpClientRequest.get(
+				`/user/installations/${installationId}/repositories`,
+			).pipe(
+				HttpClientRequest.setUrlParams({
+					per_page: options?.["per_page"] as any,
+					page: options?.["page"] as any,
+				}),
+				withResponse(
+					HttpClientResponse.matchStatus({
+						"2xx": decodeSuccess(
+							AppsListInstallationReposForAuthenticatedUser200,
+						),
+						"403": decodeError("BasicError", BasicError),
+						"404": decodeError("BasicError", BasicError),
+						"304": () => Effect.void,
+						orElse: unexpectedStatus,
+					}),
+				),
+			),
+		issuesListForRepo: (owner, repo, options) =>
+			HttpClientRequest.get(`/repos/${owner}/${repo}/issues`).pipe(
+				HttpClientRequest.setUrlParams({
+					milestone: options?.["milestone"] as any,
+					state: options?.["state"] as any,
+					assignee: options?.["assignee"] as any,
+					type: options?.["type"] as any,
+					creator: options?.["creator"] as any,
+					mentioned: options?.["mentioned"] as any,
+					labels: options?.["labels"] as any,
+					sort: options?.["sort"] as any,
+					direction: options?.["direction"] as any,
+					since: options?.["since"] as any,
+					per_page: options?.["per_page"] as any,
+					page: options?.["page"] as any,
+				}),
+				withResponse(
+					HttpClientResponse.matchStatus({
+						"200": decodeSuccess(IssuesListForRepo200),
+						"301": decodeSuccess(BasicError),
+						"404": decodeError("BasicError", BasicError),
+						"422": decodeError("ValidationError", ValidationError),
+						orElse: unexpectedStatus,
+					}),
+				),
+			),
+		issuesCreate: (owner, repo, options) =>
+			HttpClientRequest.post(`/repos/${owner}/${repo}/issues`).pipe(
+				HttpClientRequest.bodyUnsafeJson(options.payload),
+				withResponse(
+					HttpClientResponse.matchStatus({
+						"2xx": decodeSuccess(Issue),
+						"400": decodeError("BasicError", BasicError),
+						"403": decodeError("BasicError", BasicError),
+						"404": decodeError("BasicError", BasicError),
+						"410": decodeError("BasicError", BasicError),
+						"422": decodeError("ValidationError", ValidationError),
+						"503": decodeError("IssuesCreate503", IssuesCreate503),
+						orElse: unexpectedStatus,
+					}),
+				),
+			),
+	};
+};
+
+export interface Client {
+	readonly httpClient: HttpClient.HttpClient;
+	/**
+	 * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+	 *
+	 * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+	 *
+	 * You can find the permissions for the installation under the `permissions` key.
+	 */
+	readonly appsListInstallationsForAuthenticatedUser: (
+		options?:
+			| typeof AppsListInstallationsForAuthenticatedUserParams.Encoded
+			| undefined,
+	) => Effect.Effect<
+		typeof AppsListInstallationsForAuthenticatedUser200.Type,
+		| HttpClientError.HttpClientError
+		| ParseError
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"BasicError", typeof BasicError.Type>
+	>;
+	/**
+	 * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
+	 *
+	 * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+	 *
+	 * The access the user has to each repository is included in the hash under the `permissions` key.
+	 */
+	readonly appsListInstallationReposForAuthenticatedUser: (
+		installationId: string,
+		options?:
+			| typeof AppsListInstallationReposForAuthenticatedUserParams.Encoded
+			| undefined,
+	) => Effect.Effect<
+		typeof AppsListInstallationReposForAuthenticatedUser200.Type,
+		| HttpClientError.HttpClientError
+		| ParseError
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"BasicError", typeof BasicError.Type>
+	>;
+	/**
+	 * List issues in a repository. Only open issues will be listed.
+	 *
+	 * > [!NOTE]
+	 * > GitHub's REST API considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull request id, use the "[List pull requests](https://docs.github.com/rest/pulls/pulls#list-pull-requests)" endpoint.
+	 *
+	 * This endpoint supports the following custom media types. For more information, see "[Media types](https://docs.github.com/rest/using-the-rest-api/getting-started-with-the-rest-api#media-types)."
+	 *
+	 * - **`application/vnd.github.raw+json`**: Returns the raw markdown body. Response will include `body`. This is the default if you do not pass any specific media type.
+	 * - **`application/vnd.github.text+json`**: Returns a text only representation of the markdown body. Response will include `body_text`.
+	 * - **`application/vnd.github.html+json`**: Returns HTML rendered from the body's markdown. Response will include `body_html`.
+	 * - **`application/vnd.github.full+json`**: Returns raw, text, and HTML representations. Response will include `body`, `body_text`, and `body_html`.
+	 */
+	readonly issuesListForRepo: (
+		owner: string,
+		repo: string,
+		options?: typeof IssuesListForRepoParams.Encoded | undefined,
+	) => Effect.Effect<
+		typeof IssuesListForRepo200.Type | typeof BasicError.Type,
+		| HttpClientError.HttpClientError
+		| ParseError
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"ValidationError", typeof ValidationError.Type>
+	>;
+	/**
+	 * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://docs.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
+	 *
+	 * This endpoint triggers [notifications](https://docs.github.com/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in secondary rate limiting. For more information, see "[Rate limits for the API](https://docs.github.com/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits)"
+	 * and "[Best practices for using the REST API](https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api)."
+	 *
+	 * This endpoint supports the following custom media types. For more information, see "[Media types](https://docs.github.com/rest/using-the-rest-api/getting-started-with-the-rest-api#media-types)."
+	 *
+	 * - **`application/vnd.github.raw+json`**: Returns the raw markdown body. Response will include `body`. This is the default if you do not pass any specific media type.
+	 * - **`application/vnd.github.text+json`**: Returns a text only representation of the markdown body. Response will include `body_text`.
+	 * - **`application/vnd.github.html+json`**: Returns HTML rendered from the body's markdown. Response will include `body_html`.
+	 * - **`application/vnd.github.full+json`**: Returns raw, text, and HTML representations. Response will include `body`, `body_text`, and `body_html`.
+	 */
+	readonly issuesCreate: (
+		owner: string,
+		repo: string,
+		options: {
+			readonly params?: typeof IssuesCreateParams.Encoded | undefined;
+			readonly payload: typeof IssuesCreateRequest.Encoded;
+		},
+	) => Effect.Effect<
+		typeof Issue.Type,
+		| HttpClientError.HttpClientError
+		| ParseError
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"BasicError", typeof BasicError.Type>
+		| ClientError<"ValidationError", typeof ValidationError.Type>
+		| ClientError<"IssuesCreate503", typeof IssuesCreate503.Type>
+	>;
+}
+
+export interface ClientError<Tag extends string, E> {
+	readonly _tag: Tag;
+	readonly request: HttpClientRequest.HttpClientRequest;
+	readonly response: HttpClientResponse.HttpClientResponse;
+	readonly cause: E;
+}
+
+class ClientErrorImpl extends Data.Error<{
+	_tag: string;
+	cause: any;
+	request: HttpClientRequest.HttpClientRequest;
+	response: HttpClientResponse.HttpClientResponse;
+}> {}
+
+export const ClientError = <Tag extends string, E>(
+	tag: Tag,
+	cause: E,
+	response: HttpClientResponse.HttpClientResponse,
+): ClientError<Tag, E> =>
+	new ClientErrorImpl({
+		_tag: tag,
+		cause,
+		response,
+		request: response.request,
+	}) as any;

--- a/packages/github-api/tsconfig.json
+++ b/packages/github-api/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@packages/typescript-config/base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*.ts", "scripts/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds OpenAPI-generated TypeScript client for GitHub API
- Provides type-safe request/response schemas for GitHub API calls

## Stack

This is part 2 of a stacked diff series to migrate to confect:

1. Vendor confect package (#837)
2. **This PR** - Add github-api package
3. Add confect schemas and setup in database
4. Migrate rate limiter functions
5. Migrate stripe functions  
6. Migrate github functions
7. Migrate server_preferences functions
8. Migrate admin functions