### PR TITLE
refactor: migrate rate limiter functions to confect

### DIFF
--- a/packages/database/convex/internal/rateLimiter.ts
+++ b/packages/database/convex/internal/rateLimiter.ts
@@ -1,41 +1,48 @@
-import { v } from "convex/values";
-import { internalMutation } from "../client";
+import { Effect, Schema } from "effect";
+import { ConfectMutationCtx, internalMutation } from "../confect";
 import { rateLimiter } from "../shared/rateLimiter";
 
+const RateLimitResult = Schema.Struct({
+	ok: Schema.Boolean,
+	retryAfter: Schema.optional(Schema.Number),
+});
+
 export const checkGitHubCreateIssue = internalMutation({
-	args: {
-		userId: v.string(),
-	},
-	returns: v.object({
-		ok: v.boolean(),
-		retryAfter: v.optional(v.number()),
+	args: Schema.Struct({
+		userId: Schema.String,
 	}),
-	handler: async (ctx, args) => {
-		const result = await rateLimiter.limit(ctx, "githubCreateIssue", {
-			key: args.userId,
-		});
-		return {
-			ok: result.ok,
-			retryAfter: result.retryAfter ?? undefined,
-		};
-	},
+	returns: RateLimitResult,
+	handler: ({ userId }) =>
+		Effect.gen(function* () {
+			const { ctx } = yield* ConfectMutationCtx;
+			const result = yield* Effect.promise(() =>
+				rateLimiter.limit(ctx, "githubCreateIssue", {
+					key: userId,
+				}),
+			);
+			return {
+				ok: result.ok,
+				retryAfter: result.retryAfter ?? undefined,
+			};
+		}),
 });
 
 export const checkGitHubFetchRepos = internalMutation({
-	args: {
-		userId: v.string(),
-	},
-	returns: v.object({
-		ok: v.boolean(),
-		retryAfter: v.optional(v.number()),
+	args: Schema.Struct({
+		userId: Schema.String,
 	}),
-	handler: async (ctx, args) => {
-		const result = await rateLimiter.limit(ctx, "githubFetchRepos", {
-			key: args.userId,
-		});
-		return {
-			ok: result.ok,
-			retryAfter: result.retryAfter ?? undefined,
-		};
-	},
+	returns: RateLimitResult,
+	handler: ({ userId }) =>
+		Effect.gen(function* () {
+			const { ctx } = yield* ConfectMutationCtx;
+			const result = yield* Effect.promise(() =>
+				rateLimiter.limit(ctx, "githubFetchRepos", {
+					key: userId,
+				}),
+			);
+			return {
+				ok: result.ok,
+				retryAfter: result.retryAfter ?? undefined,
+			};
+		}),
 });


### PR DESCRIPTION
## Summary

Migrates rate limiter functions to use Effect-based confect patterns:

| Function | Type |
|----------|------|
| `checkGitHubCreateIssue` | internalMutation |
| `checkGitHubFetchRepos` | internalMutation |

## Stack

This is part 4 of a stacked diff series to migrate to confect:

1. Vendor confect package (#837)
2. Add github-api package (#838)
3. Add confect schemas and setup in database (#839)
4. **This PR** - Migrate rate limiter functions
5. Migrate stripe functions  
6. Migrate github functions
7. Migrate server_preferences functions
8. Migrate admin functions