### PR TITLE
refactor: migrate server_preferences functions to confect

### DIFF
--- a/packages/database/convex/private/server_preferences.ts
+++ b/packages/database/convex/private/server_preferences.ts
@@ -1,6 +1,12 @@
+import { Effect, Option, Schema } from "effect";
 import { v } from "convex/values";
 import { getOneFrom } from "convex-helpers/server/relationships";
-import { internalQuery, privateMutation, privateQuery } from "../client";
+import {
+	ConfectQueryCtx,
+	internalQuery as confectInternalQuery,
+} from "../confect";
+import { ServerPreferencesSchema } from "../schema";
+import { privateMutation, privateQuery } from "../client";
 import { planValidator } from "../schema";
 import { validateCustomDomainUniqueness } from "../shared/shared";
 
@@ -182,21 +188,21 @@ export const updateStripeSubscription = privateMutation({
 	},
 });
 
-export const getServerPreferencesByCustomDomain = internalQuery({
-	args: {
-		customDomain: v.string(),
-	},
-	handler: async (ctx, args) => {
-		const preferences = await getOneFrom(
-			ctx.db,
-			"serverPreferences",
-			"by_customDomain",
-			args.customDomain,
-			"customDomain",
-		);
+export const getServerPreferencesByCustomDomain = confectInternalQuery({
+	args: Schema.Struct({
+		customDomain: Schema.String,
+	}),
+	returns: Schema.NullOr(ServerPreferencesSchema),
+	handler: ({ customDomain }) =>
+		Effect.gen(function* () {
+			const { db } = yield* ConfectQueryCtx;
+			const preferencesOption = yield* db
+				.query("serverPreferences")
+				.withIndex("by_customDomain", (q) => q.eq("customDomain", customDomain))
+				.first();
 
-		return preferences ?? null;
-	},
+			return Option.getOrNull(preferencesOption);
+		}),
 });
 
 const ADVANCED_AND_ABOVE_PLANS = [


### PR DESCRIPTION
## Summary

Migrates server_preferences functions to use Effect-based confect patterns:

| Function | Type |
|----------|------|
| `getServerPreferencesByCustomDomain` | internalQuery |

## Stack

This is part 7 of a stacked diff series to migrate to confect:

1. Vendor confect package (#837)
2. Add github-api package (#838)
3. Add confect schemas and setup in database (#839)
4. Migrate rate limiter functions (#840)
5. Migrate stripe functions (#841)
6. Migrate github functions (#842)
7. **This PR** - Migrate server_preferences functions
8. Migrate admin functions