### PR TITLE
Hide navbar on scroll when on mobile

### DIFF
--- a/packages/ui/src/components/navbar/navbar-base.tsx
+++ b/packages/ui/src/components/navbar/navbar-base.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import type * as React from "react";
+import { cn } from "../../lib/utils";
+import { useHideOnScroll } from "../../hooks/use-hide-on-scroll";
+import { useIsMobile } from "../../hooks/use-mobile";
 import { useIsImpersonating } from "../impersonation-banner";
 
 export interface NavbarBaseProps {
@@ -15,10 +18,15 @@ export function NavbarBase({
 	rightContent,
 }: NavbarBaseProps) {
 	const isImpersonating = useIsImpersonating();
+	const isMobile = useIsMobile();
+	const isHidden = useHideOnScroll(isMobile);
 
 	return (
 		<header
-			className="fixed left-0 z-40 h-navbar w-full bg-background/95 backdrop-blur-sm border-b border-border px-4"
+			className={cn(
+				"fixed left-0 z-40 h-navbar w-full bg-background/95 backdrop-blur-sm border-b border-border px-4 transition-transform duration-300",
+				isHidden && "-translate-y-full",
+			)}
 			style={{ top: isImpersonating ? "40px" : "0" }}
 		>
 			<nav className="relative z-10 flex size-full flex-1 items-center justify-between gap-4">

--- a/packages/ui/src/components/navbar/tenant-navbar.tsx
+++ b/packages/ui/src/components/navbar/tenant-navbar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { cn } from "../../lib/utils";
+import { useHideOnScroll } from "../../hooks/use-hide-on-scroll";
+import { useIsMobile } from "../../hooks/use-mobile";
 import { useIsImpersonating } from "../impersonation-banner";
 import { Link } from "../link";
 import { ServerIcon } from "../server-icon";
@@ -17,12 +19,15 @@ export type TenantNavbarProps = {
 
 export function TenantNavbar({ showBorder = true, server }: TenantNavbarProps) {
 	const isImpersonating = useIsImpersonating();
+	const isMobile = useIsMobile();
+	const isHidden = useHideOnScroll(isMobile);
 
 	return (
 		<header
 			className={cn(
-				"fixed left-0 z-40 h-navbar w-full bg-background/95 backdrop-blur-sm px-4",
+				"fixed left-0 z-40 h-navbar w-full bg-background/95 backdrop-blur-sm px-4 transition-transform duration-300",
 				showBorder && "border-b border-border",
+				isHidden && "-translate-y-full",
 			)}
 			style={{ top: isImpersonating ? "40px" : "0" }}
 		>

--- a/packages/ui/src/hooks/use-hide-on-scroll.ts
+++ b/packages/ui/src/hooks/use-hide-on-scroll.ts
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+export function useHideOnScroll(enabled: boolean) {
+	const [isHidden, setIsHidden] = React.useState(false);
+	const lastScrollY = React.useRef(0);
+
+	React.useEffect(() => {
+		if (!enabled) {
+			setIsHidden(false);
+			return;
+		}
+
+		const handleScroll = () => {
+			const currentScrollY = window.scrollY;
+			const scrollingDown = currentScrollY > lastScrollY.current;
+			const scrolledPastThreshold = currentScrollY > 60;
+
+			if (scrollingDown && scrolledPastThreshold) {
+				setIsHidden(true);
+			} else if (!scrollingDown) {
+				setIsHidden(false);
+			}
+
+			lastScrollY.current = currentScrollY;
+		};
+
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, [enabled]);
+
+	return isHidden;
+}


### PR DESCRIPTION
## Summary
- Adds `useHideOnScroll` hook that tracks scroll direction and hides elements when scrolling down on mobile
- Updates `NavbarBase` and `TenantNavbar` components to hide when scrolling down (past 60px threshold)
- Navbar reappears immediately when scrolling up with a smooth 300ms transition