### PR TITLE
Add tags to remove on solve feature

### DIFF
--- a/packages/database/convex/authenticated/dashboard_queries.ts
+++ b/packages/database/convex/authenticated/dashboard_queries.ts
@@ -68,6 +68,7 @@ export const getDashboardData = guildManagerQuery({
 					excludeFromSimilarThreads:
 						settings?.excludeFromSimilarThreads ?? false,
 					solutionTagId: settings?.solutionTagId,
+					tagsToRemoveOnSolve: settings?.tagsToRemoveOnSolve ?? [],
 					purpose: settings?.purpose,
 				},
 			};

--- a/packages/database/convex/schema.ts
+++ b/packages/database/convex/schema.ts
@@ -107,6 +107,9 @@ const ChannelSettingsSchema = Schema.Struct({
 	autoThreadEnabled: Schema.Boolean,
 	forumGuidelinesConsentEnabled: Schema.Boolean,
 	solutionTagId: Schema.optional(Schema.BigIntFromSelf),
+	tagsToRemoveOnSolve: Schema.optional(
+		Schema.Array(Schema.BigIntFromSelf).pipe(Schema.mutable),
+	),
 	lastIndexedSnowflake: Schema.optional(Schema.BigIntFromSelf),
 	inviteCode: Schema.optional(Schema.String),
 	excludeFromSimilarThreads: Schema.optional(Schema.Boolean),

--- a/packages/database/convex/shared/channels.ts
+++ b/packages/database/convex/shared/channels.ts
@@ -29,6 +29,7 @@ export const DEFAULT_CHANNEL_SETTINGS = {
 	autoThreadEnabled: false,
 	forumGuidelinesConsentEnabled: false,
 	solutionTagId: undefined,
+	tagsToRemoveOnSolve: undefined,
 	lastIndexedSnowflake: undefined,
 	inviteCode: undefined,
 	excludeFromSimilarThreads: undefined,


### PR DESCRIPTION
## Summary

Adds the ability to configure tags that will be automatically removed when a thread is marked as solved in forum channels.

- Added `tagsToRemoveOnSolve` field to channel settings schema (array of tag IDs)
- New multi-select UI component in dashboard channel settings (appears below "Choose Solved Tag")
- Tags currently set as the solution tag are disabled with tooltip "Remove from Solution Tag first"
- Discord bot removes configured tags when marking a solution, before adding the solution tag
- Includes optimistic updates for instant UI feedback

## Changes

- **Schema**: Added `tagsToRemoveOnSolve` to `ChannelSettingsSchema`
- **Queries**: Returns `tagsToRemoveOnSolve` in dashboard channel flags
- **Mutations**: New `updateChannelTagsToRemoveOnSolve` mutation with tag validation
- **UI**: New `ChooseTagsToRemoveOnSolveCard` component with multi-select dropdown
- **Bot**: Modified mark-solution command to remove tags before adding solution tag