### PR TITLE
feat: Server-level MCP integration for chat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,7 @@
       "name": "@packages/ai",
       "version": "1.0.0",
       "dependencies": {
+        "@ai-sdk/mcp": "1.0.2",
         "@opencode-ai/sdk": "^1.0.219",
         "ai": "catalog:",
         "just-bash": "^1.2.5",
@@ -515,7 +516,7 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.16", "", { "dependencies": { "@ai-sdk/provider": "3.0.4", "@ai-sdk/provider-utils": "4.0.8", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OOY5CfRJiHvh/8np2vs1RQaCZ5hWv2qOeEmmeiABXK3gLQHUVnCO+1hhoLsZdHM5iElu6M407dAOfyvTsKJqcQ=="],
 
-    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.10", "", { "dependencies": { "@ai-sdk/provider": "3.0.4", "@ai-sdk/provider-utils": "4.0.8", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8/+l5oO/8jGXLD5Ddns6pDVO9AW5GEPB9jZ+vWkSKoBjHJlfdyHRXvonqLrJPitzPAoAixwqoRKCWNcctIZm9w=="],
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.2", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.2", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1ukAZDVyRA968d/qPa8RA+LiXf2QFbEbZrlW/1/D8y1a1i8dw4JbsfeiSk3FsvPYkjojhCCouaz3dkiWE8hlaQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.12", "", { "dependencies": { "@ai-sdk/provider": "3.0.4", "@ai-sdk/provider-utils": "4.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zqLWEKuaKnjXhu7xCw1jgz/+yTbd3F7EtgU4T2Q8BAo8OJC5wZv14l+kwM7Jai7M1/2Y2T/zBkrfiIu+7NsvfQ=="],
 
@@ -5131,9 +5132,9 @@
 
     "@opentelemetry/sql-common/@opentelemetry/core": ["@opentelemetry/core@2.4.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw=="],
 
-    "@packages/database/@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
+    "@packages/database/@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.10", "", { "dependencies": { "@ai-sdk/provider": "3.0.4", "@ai-sdk/provider-utils": "4.0.8", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8/+l5oO/8jGXLD5Ddns6pDVO9AW5GEPB9jZ+vWkSKoBjHJlfdyHRXvonqLrJPitzPAoAixwqoRKCWNcctIZm9w=="],
 
-    "@packages/main-site/@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.2", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.2", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1ukAZDVyRA968d/qPa8RA+LiXf2QFbEbZrlW/1/D8y1a1i8dw4JbsfeiSk3FsvPYkjojhCCouaz3dkiWE8hlaQ=="],
+    "@packages/database/@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
 
     "@packages/main-site/posthog-node": ["posthog-node@5.21.1", "", { "dependencies": { "@posthog/core": "1.10.0" } }, "sha512-xFRlaZTrVfIVrRfEZsI/DM6pdJqeX6iaRlo46nexhB1wfRcuIy1mtp76nkZSw3DDRXBczTo41K7raO2yS3dxzA=="],
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -22,6 +22,7 @@
 		"test:clone": "bun run scripts/test-clone.ts"
 	},
 	"dependencies": {
+		"@ai-sdk/mcp": "1.0.2",
 		"@opencode-ai/sdk": "^1.0.219",
 		"ai": "catalog:",
 		"just-bash": "^1.2.5",

--- a/packages/ai/src/tools/index.ts
+++ b/packages/ai/src/tools/index.ts
@@ -9,6 +9,13 @@ export {
 	type VirtualBashResult,
 } from "../sandbox/virtual-bash";
 export {
+	createMCPToolsFromServers,
+	getMCPServerFromToolName,
+	type MCPConnectionResult,
+	type MCPServerConfig,
+	type MCPToolsResult,
+} from "./mcp-tools";
+export {
 	createSandboxTools,
 	type SandboxBashInput,
 	type SandboxEditInput,

--- a/packages/ai/src/tools/mcp-tools.ts
+++ b/packages/ai/src/tools/mcp-tools.ts
@@ -1,0 +1,136 @@
+import { createMCPClient, type MCPClient } from "@ai-sdk/mcp";
+import type { Tool } from "ai";
+
+export type MCPServerConfig = {
+	name: string;
+	url: string;
+};
+
+export type MCPConnectionResult = {
+	serverName: string;
+	tools: Record<string, Tool>;
+	error?: string;
+};
+
+export type MCPToolsResult = {
+	tools: Record<string, Tool>;
+	connections: MCPConnectionResult[];
+};
+
+const MCP_CONNECTION_TIMEOUT = 10000;
+const MCP_TOOL_PREFIX_SEPARATOR = "__";
+
+function prefixToolName(serverName: string, toolName: string): string {
+	const sanitizedServerName = serverName
+		.toLowerCase()
+		.replace(/[^a-z0-9]/g, "_")
+		.replace(/_+/g, "_")
+		.replace(/^_|_$/g, "");
+	return `${sanitizedServerName}${MCP_TOOL_PREFIX_SEPARATOR}${toolName}`;
+}
+
+function prefixTools(
+	tools: Record<string, Tool>,
+	serverName: string,
+): Record<string, Tool> {
+	const prefixedTools: Record<string, Tool> = {};
+	for (const [name, tool] of Object.entries(tools)) {
+		const prefixedName = prefixToolName(serverName, name);
+		prefixedTools[prefixedName] = {
+			...tool,
+			description: `[${serverName}] ${tool.description ?? ""}`,
+		};
+	}
+	return prefixedTools;
+}
+
+async function connectToMCPServer(
+	server: MCPServerConfig,
+): Promise<{ client: MCPClient; tools: Record<string, Tool> }> {
+	const client = await createMCPClient({
+		transport: {
+			type: "http",
+			url: server.url,
+		},
+		name: `answeroverflow-chat-${server.name.replace(/[^a-z0-9]/gi, "-")}`,
+		version: "1.0.0",
+	});
+
+	const tools = await client.tools();
+
+	return { client, tools };
+}
+
+export async function createMCPToolsFromServers(
+	servers: MCPServerConfig[],
+): Promise<MCPToolsResult> {
+	if (servers.length === 0) {
+		return { tools: {}, connections: [] };
+	}
+
+	const connections: MCPConnectionResult[] = [];
+	const allTools: Record<string, Tool> = {};
+
+	const connectionPromises = servers.map(async (server) => {
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			setTimeout(
+				() =>
+					reject(
+						new Error(`Connection timeout after ${MCP_CONNECTION_TIMEOUT}ms`),
+					),
+				MCP_CONNECTION_TIMEOUT,
+			);
+		});
+
+		try {
+			const { tools } = await Promise.race([
+				connectToMCPServer(server),
+				timeoutPromise,
+			]);
+
+			const prefixedTools = prefixTools(tools, server.name);
+
+			return {
+				serverName: server.name,
+				tools: prefixedTools,
+			};
+		} catch (error) {
+			const errorMessage =
+				error instanceof Error ? error.message : "Unknown error";
+			console.warn(
+				`Failed to connect to MCP server "${server.name}" (${server.url}): ${errorMessage}`,
+			);
+			return {
+				serverName: server.name,
+				tools: {},
+				error: errorMessage,
+			};
+		}
+	});
+
+	const results = await Promise.allSettled(connectionPromises);
+
+	for (const result of results) {
+		if (result.status === "fulfilled") {
+			connections.push(result.value);
+			Object.assign(allTools, result.value.tools);
+		}
+	}
+
+	return { tools: allTools, connections };
+}
+
+export function getMCPServerFromToolName(
+	toolName: string,
+): { serverName: string; originalToolName: string } | null {
+	const separatorIndex = toolName.indexOf(MCP_TOOL_PREFIX_SEPARATOR);
+	if (separatorIndex === -1) {
+		return null;
+	}
+	return {
+		serverName: toolName.slice(0, separatorIndex),
+		originalToolName: toolName.slice(
+			separatorIndex + MCP_TOOL_PREFIX_SEPARATOR.length,
+		),
+	};
+}

--- a/packages/database/convex/schema.ts
+++ b/packages/database/convex/schema.ts
@@ -32,6 +32,11 @@ const PlanSchema = Schema.Literal(
 
 const ChannelPurposeSchema = Schema.Literal("HELP", "GENERAL");
 
+const MCPServerConfigSchema = Schema.Struct({
+	name: Schema.String,
+	url: Schema.String,
+});
+
 const ServerPreferencesSchema = Schema.Struct({
 	serverId: Schema.BigIntFromSelf,
 	stripeCustomerId: Schema.optional(Schema.String),
@@ -49,6 +54,9 @@ const ServerPreferencesSchema = Schema.Struct({
 	botAvatarStorageId: Schema.optional(Id.Id("_storage")),
 	botBannerStorageId: Schema.optional(Id.Id("_storage")),
 	botBio: Schema.optional(Schema.String),
+	mcpServers: Schema.optional(
+		Schema.Array(MCPServerConfigSchema).pipe(Schema.mutable),
+	),
 });
 
 const ServerSchema = Schema.Struct({
@@ -562,6 +570,7 @@ export type Embed = Schema.Schema.Type<typeof EmbedSchema>;
 export type ForumTag = Schema.Schema.Type<typeof ForumTagSchema>;
 export type AgentStatus = Schema.Schema.Type<typeof AgentStatusSchema>;
 export type ChannelPurpose = Schema.Schema.Type<typeof ChannelPurposeSchema>;
+export type MCPServerConfig = Schema.Schema.Type<typeof MCPServerConfigSchema>;
 export type ComponentButton = Schema.Schema.Type<typeof ComponentButtonSchema>;
 export type ComponentThumbnail = Schema.Schema.Type<
 	typeof ComponentThumbnailSchema

--- a/packages/database/src/analytics/events/client.ts
+++ b/packages/database/src/analytics/events/client.ts
@@ -113,6 +113,14 @@ export type ClientEvents = {
 		guildId: string;
 		inviteUrl: string;
 	};
+	"Server MCP Config Added": {
+		serverDiscordId: string;
+		mcpServerName: string;
+	};
+	"Server MCP Config Removed": {
+		serverDiscordId: string;
+		mcpServerName: string;
+	};
 };
 
 export type ClientEventName = keyof ClientEvents;


### PR DESCRIPTION
## Summary

Enables Discord server admins to configure MCP (Model Context Protocol) servers for their communities. When users chat about a Discord server on Answer Overflow, the AI will have access to tools from that server's configured MCP servers.

## Changes

- Add `MCPServerConfig` schema to server preferences (`mcpServers` field)
- Create MCP client wrapper utilities (`packages/ai/src/tools/mcp-tools.ts`):
  - `createMCPToolsFromServers()` - Connects to multiple HTTP MCP servers and aggregates their tools
  - Tools are prefixed with server name to avoid collisions (e.g., `my_server__tool_name`)
  - 10 second timeout, graceful error handling
- Integrate MCP tools into `streamChat()` - fetches MCP servers from server preferences when a server context is provided
- Add analytics events for server MCP config management

## How It Works

1. Server admin configures MCP servers in their server preferences (name + URL pairs)
2. When a user starts a chat with that server's context, `streamChat()` fetches the server's MCP config
3. MCP tools from all configured servers are loaded and made available to the AI agent
4. Tool names are prefixed to avoid collisions between servers

## Next Steps

- [ ] Create server admin UI for managing MCP servers (in dashboard/server settings)
- [ ] Add server preference mutations for MCP management (admin-only)

## Testing

To test manually:
1. Add MCP servers to a server's preferences via Convex dashboard
2. Start a chat with that server's context
3. Verify MCP tools appear and work in the chat