### PR TITLE
add analytics, metrics, and tracing for GitHub issue feature

### DIFF
--- a/apps/discord-bot/src/metrics.ts
+++ b/apps/discord-bot/src/metrics.ts
@@ -58,3 +58,50 @@ export const indexingDuration = Metric.histogram(
 	MetricBoundaries.linear({ start: 100, width: 1000, count: 10 }),
 	"Duration of indexing operations in milliseconds",
 );
+
+export const githubIssuesCreated = Metric.counter(
+	"discord.github_issues.created",
+	{
+		description: "Number of GitHub issues successfully created",
+	},
+);
+
+export const githubIssuesFailed = Metric.counter(
+	"discord.github_issues.failed",
+	{
+		description: "Number of GitHub issue creation failures",
+	},
+);
+
+export const githubIssueAIExtractions = Metric.counter(
+	"discord.github_issues.ai_extractions",
+	{
+		description: "Number of AI issue extraction attempts",
+	},
+);
+
+export const githubIssueAIFallbacks = Metric.counter(
+	"discord.github_issues.ai_fallbacks",
+	{
+		description: "Number of times AI extraction fell back to manual",
+	},
+);
+
+export const githubIssueRateLimits = Metric.counter(
+	"discord.github_issues.rate_limits",
+	{
+		description: "Number of GitHub issue rate limit hits",
+	},
+);
+
+export const githubIssueAIExtractionDuration = Metric.histogram(
+	"discord.github_issues.ai_extraction_duration_ms",
+	MetricBoundaries.linear({ start: 100, width: 500, count: 20 }),
+	"Duration of AI issue extraction in milliseconds",
+);
+
+export const githubIssueCommandDuration = Metric.histogram(
+	"discord.github_issues.command_duration_ms",
+	MetricBoundaries.linear({ start: 100, width: 1000, count: 20 }),
+	"Duration of full GitHub issue command in milliseconds",
+);

--- a/apps/discord-bot/src/utils/analytics.ts
+++ b/apps/discord-bot/src/utils/analytics.ts
@@ -305,3 +305,106 @@ export function trackSimilarThreadSolvedClicked(
 		accountId: member.id,
 	});
 }
+
+export function trackGitHubIssueCommandUsed(input: {
+	userId: string;
+	guildId: string;
+	channelId: string;
+	messageId: string;
+	threadId?: string;
+}) {
+	return track("GitHub Issue Command Used", {
+		user: { id: input.userId },
+		"Server Id": input.guildId,
+		"Channel Id": input.channelId,
+		"Message Id": input.messageId,
+		"Thread Id": input.threadId,
+		accountId: input.userId,
+	});
+}
+
+export function trackGitHubIssueCreated(input: {
+	userId: string;
+	guildId: string;
+	channelId: string;
+	messageId: string;
+	threadId?: string;
+	repoOwner: string;
+	repoName: string;
+	issueNumber: number;
+	issueUrl: string;
+	issuesInBatch: number;
+}) {
+	return track("GitHub Issue Created", {
+		user: { id: input.userId },
+		"Server Id": input.guildId,
+		"Channel Id": input.channelId,
+		"Message Id": input.messageId,
+		"Thread Id": input.threadId,
+		"Repo Owner": input.repoOwner,
+		"Repo Name": input.repoName,
+		"Issue Number": input.issueNumber,
+		"Issue URL": input.issueUrl,
+		"Issues In Batch": input.issuesInBatch,
+		accountId: input.userId,
+	});
+}
+
+export function trackGitHubIssueCreationFailed(input: {
+	userId: string;
+	guildId: string;
+	channelId: string;
+	messageId: string;
+	errorType: string;
+	errorMessage: string;
+	repoOwner?: string;
+	repoName?: string;
+}) {
+	return track("GitHub Issue Creation Failed", {
+		user: { id: input.userId },
+		"Server Id": input.guildId,
+		"Channel Id": input.channelId,
+		"Message Id": input.messageId,
+		"Error Type": input.errorType,
+		"Error Message": input.errorMessage,
+		"Repo Owner": input.repoOwner,
+		"Repo Name": input.repoName,
+		accountId: input.userId,
+	});
+}
+
+export function trackGitHubIssueAIExtraction(input: {
+	userId: string;
+	guildId: string;
+	channelId: string;
+	messageId: string;
+	issuesExtracted: number;
+	usedFallback: boolean;
+	messageLength: number;
+}) {
+	return track("GitHub Issue AI Extraction", {
+		user: { id: input.userId },
+		"Server Id": input.guildId,
+		"Channel Id": input.channelId,
+		"Message Id": input.messageId,
+		"Issues Extracted": input.issuesExtracted,
+		"Used Fallback": input.usedFallback,
+		"Message Length": input.messageLength,
+		accountId: input.userId,
+	});
+}
+
+export function trackGitHubIssueRateLimited(input: {
+	userId: string;
+	guildId: string;
+	rateLimitType: "ai_extraction" | "issue_creation";
+	retryAfterSeconds: number;
+}) {
+	return track("GitHub Issue Rate Limited", {
+		user: { id: input.userId },
+		"Server Id": input.guildId,
+		"Rate Limit Type": input.rateLimitType,
+		"Retry After Seconds": input.retryAfterSeconds,
+		accountId: input.userId,
+	});
+}

--- a/packages/database/src/analytics/events/server.ts
+++ b/packages/database/src/analytics/events/server.ts
@@ -95,6 +95,53 @@ export type ServerEvents = {
 	> & {
 		"Similar Thread Id": string;
 	};
+
+	"GitHub Issue Command Used": Pick<BaseServerProps, "user" | "accountId"> & {
+		"Server Id": string;
+		"Channel Id": string;
+		"Message Id": string;
+		"Thread Id"?: string;
+	};
+
+	"GitHub Issue Created": Pick<BaseServerProps, "user" | "accountId"> & {
+		"Server Id": string;
+		"Channel Id": string;
+		"Message Id": string;
+		"Thread Id"?: string;
+		"Repo Owner": string;
+		"Repo Name": string;
+		"Issue Number": number;
+		"Issue URL": string;
+		"Issues In Batch": number;
+	};
+
+	"GitHub Issue Creation Failed": Pick<
+		BaseServerProps,
+		"user" | "accountId"
+	> & {
+		"Server Id": string;
+		"Channel Id": string;
+		"Message Id": string;
+		"Error Type": string;
+		"Error Message": string;
+		"Repo Owner"?: string;
+		"Repo Name"?: string;
+	};
+
+	"GitHub Issue AI Extraction": Pick<BaseServerProps, "user" | "accountId"> & {
+		"Server Id": string;
+		"Channel Id": string;
+		"Message Id": string;
+		"Issues Extracted": number;
+		"Used Fallback": boolean;
+		"Message Length": number;
+	};
+
+	"GitHub Issue Rate Limited": Pick<BaseServerProps, "user" | "accountId"> & {
+		"Server Id": string;
+		"Rate Limit Type": "ai_extraction" | "issue_creation";
+		"Retry After Seconds": number;
+	};
 };
 
 export type ServerEventName = keyof ServerEvents;


### PR DESCRIPTION
## Summary

- Adds full observability instrumentation for the Convert to GitHub Issue feature
- PostHog analytics events track command usage, issue creation success/failure, AI extraction stats, and rate limits
- Effect metrics (counters + histograms) for success/failure rates and latency percentiles (exported to Axiom)
- Rich span annotations throughout the command flow for distributed tracing and debugging

## Changes

### PostHog Analytics (5 new events)
- **GitHub Issue Command Used** — every invocation
- **GitHub Issue Created** — successful creation with repo/issue metadata
- **GitHub Issue Creation Failed** — failures with error type and message
- **GitHub Issue AI Extraction** — AI extraction results (issue count, fallback status, message length)
- **GitHub Issue Rate Limited** — rate limit hits with retry timing

### Effect Metrics (7 new metrics)
- Counters: `github_issues.created`, `github_issues.failed`, `github_issues.ai_extractions`, `github_issues.ai_fallbacks`, `github_issues.rate_limits`
- Histograms: `github_issues.ai_extraction_duration_ms`, `github_issues.command_duration_ms`

### Tracing Spans
- `convert_to_github_issue_command` — annotated with target message metadata, thread/forum context, server settings, AI extraction results
- `extract_issues_from_message` → `ai_generate_text` — AI model, input/output details
- `create_github_issue` → `create_github_issue_api_call` — repo, issue number, error codes on failure

### Files changed
- `packages/database/src/analytics/events/server.ts` — new event type definitions
- `apps/discord-bot/src/utils/analytics.ts` — new tracking wrapper functions
- `apps/discord-bot/src/metrics.ts` — new counters and histograms
- `apps/discord-bot/src/commands/convert-to-github-issue-reacord.tsx` — wired up analytics, metrics, and span annotations
- `apps/discord-bot/src/commands/extract-github-issues.ts` — added tracing spans for AI extraction