### PR TITLE
Remove high-cardinality generateStaticParams to reduce ISR writes

### DIFF
--- a/apps/main-site/src/app/(main-site)/c/[serverId]/[channelId]/page.tsx
+++ b/apps/main-site/src/app/(main-site)/c/[serverId]/[channelId]/page.tsx
@@ -1,9 +1,8 @@
-import { Database } from "@packages/database/database";
 import { ChannelThreadCardSkeleton } from "@packages/ui/components/thread-card";
 import { decodeCursor } from "@packages/ui/utils/cursor";
 import { getServerCustomUrl } from "@packages/ui/utils/server";
 import { parseSnowflakeId } from "@packages/ui/utils/snowflake";
-import { Effect, Option } from "effect";
+import { Option } from "effect";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -13,35 +12,9 @@ import {
 	fetchChannelPageHeaderData,
 	generateChannelPageMetadata,
 } from "../../../../../components/channel-page-loader";
-import { runtime } from "../../../../../lib/runtime";
 
-export async function generateStaticParams() {
-	const servers = await Effect.gen(function* () {
-		const database = yield* Database;
-		return yield* database.public.servers.getBrowseServers({});
-	}).pipe(runtime.runPromise);
-
-	const params: Array<{ serverId: string; channelId: string }> = [];
-
-	for (const server of servers.slice(0, 5)) {
-		const serverData = await Effect.gen(function* () {
-			const database = yield* Database;
-			return yield* database.public.servers.getServerByDiscordIdWithChannels({
-				discordId: server.discordId,
-			});
-		}).pipe(runtime.runPromise);
-
-		if (serverData?.channels) {
-			for (const channel of serverData.channels.slice(0, 2)) {
-				params.push({
-					serverId: server.discordId.toString(),
-					channelId: channel.id.toString(),
-				});
-			}
-		}
-	}
-
-	return params;
+export function generateStaticParams() {
+	return [{ serverId: "placeholder", channelId: "placeholder" }];
 }
 
 type Props = {

--- a/apps/main-site/src/app/(main-site)/c/[serverId]/page.tsx
+++ b/apps/main-site/src/app/(main-site)/c/[serverId]/page.tsx
@@ -1,10 +1,9 @@
-import { Database } from "@packages/database/database";
 import { ServerIcon } from "@packages/ui/components/server-icon";
 import { ChannelThreadCardSkeleton } from "@packages/ui/components/thread-card";
 import { decodeCursor } from "@packages/ui/utils/cursor";
 import { getServerCustomUrl } from "@packages/ui/utils/server";
 import { parseSnowflakeId } from "@packages/ui/utils/snowflake";
-import { Effect, Option } from "effect";
+import { Option } from "effect";
 import { Hash } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
@@ -15,17 +14,9 @@ import {
 	generateServerPageMetadata,
 	ServerPageLoader,
 } from "../../../../components/channel-page-loader";
-import { runtime } from "../../../../lib/runtime";
 
-export async function generateStaticParams() {
-	const servers = await Effect.gen(function* () {
-		const database = yield* Database;
-		return yield* database.public.servers.getBrowseServers({});
-	}).pipe(runtime.runPromise);
-
-	return servers.slice(0, 10).map((server) => ({
-		serverId: server.discordId.toString(),
-	}));
+export function generateStaticParams() {
+	return [{ serverId: "placeholder" }];
 }
 
 type Props = {

--- a/apps/main-site/src/app/(main-site)/dashboard/[serverId]/layout.tsx
+++ b/apps/main-site/src/app/(main-site)/dashboard/[serverId]/layout.tsx
@@ -1,18 +1,3 @@
-import { Database } from "@packages/database/database";
-import { Effect } from "effect";
-import { runtime } from "@/lib/runtime";
-
-export async function generateStaticParams() {
-	const servers = await Effect.gen(function* () {
-		const database = yield* Database;
-		return yield* database.public.servers.getBrowseServers({});
-	}).pipe(runtime.runPromise);
-
-	return servers.slice(0, 3).map((server) => ({
-		serverId: server.discordId.toString(),
-	}));
-}
-
 export default function ServerIdLayout({
 	children,
 }: {

--- a/apps/main-site/src/app/(main-site)/m/[messageId]/page.tsx
+++ b/apps/main-site/src/app/(main-site)/m/[messageId]/page.tsx
@@ -1,8 +1,7 @@
-import { Database } from "@packages/database/database";
 import { decodeCursor } from "@packages/ui/utils/cursor";
 import { getServerCustomUrl } from "@packages/ui/utils/server";
 import { parseSnowflakeId } from "@packages/ui/utils/snowflake";
-import { Effect, Option } from "effect";
+import { Option } from "effect";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -12,19 +11,9 @@ import {
 	MessagePageLoader,
 	MessagePageSkeleton,
 } from "../../../../components/message-page-loader";
-import { runtime } from "../../../../lib/runtime";
 
-export async function generateStaticParams() {
-	const result = await Effect.gen(function* () {
-		const database = yield* Database;
-		return yield* database.public.search.getRecentThreads({
-			paginationOpts: { numItems: 10, cursor: null },
-		});
-	}).pipe(runtime.runPromise);
-
-	return result.page.map((thread) => ({
-		messageId: thread.message.message.id.toString(),
-	}));
+export function generateStaticParams() {
+	return [{ messageId: "placeholder" }];
 }
 
 type Props = {

--- a/apps/main-site/src/app/[domain]/(content)/c/[channelId]/page.tsx
+++ b/apps/main-site/src/app/[domain]/(content)/c/[channelId]/page.tsx
@@ -4,7 +4,6 @@ import { getTenantCanonicalUrl } from "@packages/ui/utils/links";
 import { parseSnowflakeId } from "@packages/ui/utils/snowflake";
 import { Option } from "effect";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
 import { CommunityPageSkeleton } from "../../../../../components/channel-page-content";
@@ -15,8 +14,8 @@ import {
 } from "../../../../../components/channel-page-loader";
 import { getTenantData } from "../../../../../lib/tenant";
 
-export async function generateStaticParams() {
-	return [{ domain: "vapi.ai", channelId: "placeholder" }];
+export function generateStaticParams() {
+	return [{ domain: "placeholder", channelId: "placeholder" }];
 }
 
 type Props = {

--- a/apps/main-site/src/app/[domain]/(content)/layout.tsx
+++ b/apps/main-site/src/app/[domain]/(content)/layout.tsx
@@ -9,14 +9,14 @@ import {
 	DomainNavbar,
 } from "../../../components/domain-navbar-footer-wrapper";
 
+export function generateStaticParams() {
+	return [{ domain: "placeholder" }];
+}
+
 type Props = {
 	children: React.ReactNode;
 	params: Promise<{ domain: string }>;
 };
-
-export async function generateStaticParams() {
-	return [{ domain: "vapi.ai" }];
-}
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
 	const params = await props.params;

--- a/apps/main-site/src/app/[domain]/(content)/m/[messageId]/page.tsx
+++ b/apps/main-site/src/app/[domain]/(content)/m/[messageId]/page.tsx
@@ -30,8 +30,8 @@ import {
 import { runtime } from "../../../../../lib/runtime";
 import { getTenantData } from "../../../../../lib/tenant";
 
-export async function generateStaticParams() {
-	return [{ domain: "vapi.ai", messageId: "placeholder" }];
+export function generateStaticParams() {
+	return [{ domain: "placeholder", messageId: "placeholder" }];
 }
 
 async function fetchTenantAndHeaderData(domain: string, messageId: bigint) {

--- a/apps/main-site/src/app/[domain]/(content)/page.tsx
+++ b/apps/main-site/src/app/[domain]/(content)/page.tsx
@@ -3,7 +3,6 @@ import { ChannelThreadCardSkeleton } from "@packages/ui/components/thread-card";
 import { decodeCursor } from "@packages/ui/utils/cursor";
 import { Hash } from "lucide-react";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { CommunityPageSkeleton } from "../../../components/channel-page-content";
@@ -14,8 +13,8 @@ import {
 } from "../../../components/channel-page-loader";
 import { getTenantData } from "../../../lib/tenant";
 
-export async function generateStaticParams() {
-	return [{ domain: "vapi.ai" }];
+export function generateStaticParams() {
+	return [{ domain: "placeholder" }];
 }
 
 type Props = {

--- a/apps/main-site/src/app/[domain]/(content)/search/page.tsx
+++ b/apps/main-site/src/app/[domain]/(content)/search/page.tsx
@@ -1,10 +1,8 @@
 import { Suspense } from "react";
 import { TenantSearchPageContent, TenantSearchSkeleton } from "./client";
 
-export async function generateStaticParams(): Promise<
-	Array<{ domain: string }>
-> {
-	return [{ domain: "vapi.ai" }];
+export function generateStaticParams() {
+	return [{ domain: "placeholder" }];
 }
 
 export default function TenantSearchPage() {

--- a/apps/main-site/src/app/[domain]/[repo]/page.tsx
+++ b/apps/main-site/src/app/[domain]/[repo]/page.tsx
@@ -1,17 +1,15 @@
 import { redirect } from "next/navigation";
 
+export function generateStaticParams() {
+	return [{ domain: "placeholder", repo: "placeholder" }];
+}
+
 type Props = {
 	params: Promise<{
 		domain: string;
 		repo: string;
 	}>;
 };
-
-export async function generateStaticParams(): Promise<
-	Array<{ domain: string; repo: string }>
-> {
-	return [{ domain: "answeroverflow", repo: "answeroverflow" }];
-}
 
 export default async function RepoPage(props: Props) {
 	const params = await props.params;


### PR DESCRIPTION
## Summary

- Replace database-fetching `generateStaticParams` with placeholder values for high-cardinality routes
- Add Suspense wrappers and skeletons for user pages and invite page
- Keep blog `generateStaticParams` unchanged (low cardinality)

## Why

With `cacheComponents` enabled in Next.js 16, placeholder `generateStaticParams` allows route validation at build time without prerendering thousands of pages. This significantly reduces build time while still allowing dynamic rendering at request time.

## Changes

**Main-site routes:**
- `c/[serverId]/page.tsx` - placeholder generateStaticParams
- `c/[serverId]/[channelId]/page.tsx` - placeholder generateStaticParams
- `m/[messageId]/page.tsx` - placeholder generateStaticParams
- `u/[userId]/page.tsx` - placeholder generateStaticParams + skeleton
- `invite/[inviteCode]/page.tsx` - placeholder generateStaticParams + skeleton
- `dashboard/[serverId]/layout.tsx` - removed generateStaticParams

**Domain tenant routes:**
- `[domain]/[repo]/page.tsx` - placeholder generateStaticParams
- `[domain]/(content)/layout.tsx` - placeholder generateStaticParams
- `[domain]/(content)/page.tsx` - placeholder generateStaticParams
- `[domain]/(content)/c/[channelId]/page.tsx` - placeholder generateStaticParams
- `[domain]/(content)/m/[messageId]/page.tsx` - placeholder generateStaticParams
- `[domain]/(content)/u/[userId]/page.tsx` - placeholder generateStaticParams + skeleton
- `[domain]/(content)/search/page.tsx` - placeholder generateStaticParams