### PR TITLE
[codex] Remove rotating sponsor ads

### DIFF
--- a/apps/main-site/src/app/[domain]/(content)/m/[messageId]/page.tsx
+++ b/apps/main-site/src/app/[domain]/(content)/m/[messageId]/page.tsx
@@ -169,7 +169,6 @@ async function TenantMessagePageContent(props: {
 	return (
 		<MessagePage
 			headerData={headerData}
-			sponsorIndex={Math.floor(Math.random() * 1000)}
 			bowieImageIndex={Math.floor(Math.random() * 1000)}
 			repliesSlot={
 				afterMessageId ? (

--- a/apps/main-site/src/components/message-page-loader.tsx
+++ b/apps/main-site/src/components/message-page-loader.tsx
@@ -265,7 +265,6 @@ export async function MessagePageLoader(props: {
 	return (
 		<MessagePage
 			headerData={headerData}
-			sponsorIndex={Math.floor(Math.random() * 1000)}
 			bowieImageIndex={Math.floor(Math.random() * 1000)}
 			repliesSlot={
 				afterMessageId ? (

--- a/apps/main-site/src/components/message-page.tsx
+++ b/apps/main-site/src/components/message-page.tsx
@@ -387,7 +387,6 @@ export function MessagePage(props: {
 	repliesSlot: ReactNode;
 	similarThreadsSlot: ReactNode;
 	recentAnnouncementsSlot?: ReactNode;
-	sponsorIndex: number;
 	bowieImageIndex: number;
 }) {
 	const {
@@ -395,7 +394,6 @@ export function MessagePage(props: {
 		repliesSlot,
 		similarThreadsSlot,
 		recentAnnouncementsSlot,
-		sponsorIndex,
 		bowieImageIndex,
 	} = props;
 
@@ -669,7 +667,6 @@ export function MessagePage(props: {
 									sponsorUrl={headerData.server.sponsorUrl}
 									serverId={headerData.server.discordId.toString()}
 									bowieImageIndex={bowieImageIndex}
-									sponsorIndex={sponsorIndex}
 								/>
 								{recentAnnouncementsSlot}
 							</div>
@@ -737,7 +734,6 @@ export function MessagePage(props: {
 									serverId: firstMessage.message.serverId.toString(),
 									channelId: firstMessage.message.channelId.toString(),
 								},
-								sponsor: !tenant ? "rotating" : null,
 							}}
 						/>
 					)}

--- a/apps/main-site/src/components/resources-sidebar.tsx
+++ b/apps/main-site/src/components/resources-sidebar.tsx
@@ -213,56 +213,6 @@ export function MCPServerResource() {
 	);
 }
 
-type ImageSponsor = {
-	type: "image";
-	name: string;
-	href: string;
-	image: string;
-	width: number;
-	height: number;
-};
-
-type CarbonSponsor = {
-	type: "carbon";
-	name: string;
-};
-
-type Sponsor = ImageSponsor | CarbonSponsor;
-
-const SPONSORS: Sponsor[] = [
-	{
-		type: "image",
-		name: "plannotator",
-		href: "https://plannotator.ai/?utm_source=www.answeroverflow.com",
-		image:
-			"https://cdn.answeroverflow.com/1486404878359335092/d2a528c0-128c-4c86-851b-1d5c9ba9e21c.jpeg",
-		width: 400,
-		height: 516,
-	},
-	{
-		type: "image",
-		name: "invent",
-		href: "https://www.useinvent.com/?utm_source=www.answeroverflow.com",
-		image:
-			"https://cdn.answeroverflow.com/1486944608360337418/064d70bc-58a7-44fc-89b6-f63f8c01173b.png",
-		width: 400,
-		height: 400,
-	},
-	{
-		type: "image",
-		name: "morphllm",
-		href: "https://www.morphllm.com/mcp?utm_source=www.answeroverflow.com",
-		image:
-			"https://cdn.answeroverflow.com/1486944590882799656/94455281-5ac3-4fa4-94c2-0f56335ca2aa.jpeg",
-		width: 400,
-		height: 400,
-	},
-	{
-		type: "carbon",
-		name: "carbon",
-	},
-];
-
 function CarbonAd() {
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -283,30 +233,6 @@ function CarbonAd() {
 	}, []);
 
 	return <div ref={containerRef} />;
-}
-
-function SponsoredContent({ sponsorIndex }: { sponsorIndex: number }) {
-	const sponsor = SPONSORS[sponsorIndex % SPONSORS.length]!;
-	return (
-		<div>
-			{sponsor.type === "image" && (
-				<TrackLink
-					href={sponsor.href}
-					eventName="Sponsored Card Click"
-					eventData={{ sponsor: sponsor.name }}
-				>
-					<Image
-						src={sponsor.image}
-						alt={sponsor.name}
-						width={sponsor.width}
-						height={sponsor.height}
-						className="w-full h-auto rounded-xl"
-					/>
-				</TrackLink>
-			)}
-			{sponsor.type === "carbon" && <CarbonAd />}
-		</div>
-	);
 }
 
 function BowieSidebarCard({ imageIndex }: { imageIndex: number }) {
@@ -333,14 +259,12 @@ export function ResourcesSidebar({
 	sponsorUrl,
 	serverId,
 	bowieImageIndex,
-	sponsorIndex,
 	showSponsor,
 }: {
 	className?: string;
 	sponsorUrl?: string | null;
 	serverId?: string;
 	bowieImageIndex?: number;
-	sponsorIndex?: number;
 	showSponsor?: boolean;
 }) {
 	const tenant = useTenant();
@@ -349,11 +273,11 @@ export function ResourcesSidebar({
 		? "GitHub Sponsor"
 		: "Support the project";
 	const showBowieCard = serverId === SUPABASE_SERVER_ID;
-	const showSponsored = showSponsor && !tenant && !showBowieCard;
+	const showCarbonAd = showSponsor && !tenant && !showBowieCard;
 
 	return (
 		<div className={cn("text-left", className)}>
-			{showSponsored && <SponsoredContent sponsorIndex={sponsorIndex ?? 0} />}
+			{showCarbonAd && <CarbonAd />}
 			{showBowieCard && <BowieSidebarCard imageIndex={bowieImageIndex ?? 0} />}
 			<div className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wide mb-2 mt-4">
 				Resources


### PR DESCRIPTION
## Summary

- Remove the rotating custom sponsor ad list and sponsor index plumbing.
- Keep the Carbon Ads sidebar placement controlled by the existing `showSponsor` flag.
- Preserve community-configured sponsor/support links in the resources sidebar.

## Validation

- `bunx biome check apps/main-site/src/components/resources-sidebar.tsx apps/main-site/src/components/message-page.tsx apps/main-site/src/components/message-page-loader.tsx 'apps/main-site/src/app/[domain]/(content)/m/[messageId]/page.tsx'`\n\n## Notes\n\nTypeScript checks were attempted earlier but could not run in this environment because `tsgo` was unavailable and the slow TypeScript path could not resolve the workspace TypeScript config.