### PR TITLE
Add internal debugging MCP

### DIFF
--- a/apps/main-site/sentry.edge.config.ts
+++ b/apps/main-site/sentry.edge.config.ts
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+	enableLogs: true,
+	sendDefaultPii: true,
+	sampleRate: 0.25,
+	tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+});

--- a/apps/main-site/sentry.server.config.ts
+++ b/apps/main-site/sentry.server.config.ts
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+	enableLogs: true,
+	sendDefaultPii: true,
+	sampleRate: 0.25,
+	tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+});

--- a/apps/main-site/src/app/(main-site)/internal/mcp/route.ts
+++ b/apps/main-site/src/app/(main-site)/internal/mcp/route.ts
@@ -1,0 +1,57 @@
+import { createMcpHandler } from "mcp-handler";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { registerInternalDebugTools } from "@/lib/mcp/internal-debug-tools";
+
+const handler = createMcpHandler(
+	(server) => {
+		registerInternalDebugTools(server);
+	},
+	{
+		instructions:
+			"Answer Overflow internal debugging tools. Start with live Convex function metadata and the issue-specific inspectors, correlate results with Discord reports, request IDs, deployment telemetry, and source code, and use mutating Convex operations only when the debugging workflow requires them.",
+	},
+	{
+		basePath: "/internal",
+		maxDuration: 60,
+	},
+);
+
+function constantTimeEqual(left: string, right: string): boolean {
+	if (left.length !== right.length) return false;
+
+	let mismatch = 0;
+	for (let index = 0; index < left.length; index += 1) {
+		mismatch |= left.charCodeAt(index) ^ right.charCodeAt(index);
+	}
+	return mismatch === 0;
+}
+
+function isAuthorized(request: NextRequest): boolean {
+	const expectedToken = process.env.BACKEND_ACCESS_TOKEN;
+	if (!expectedToken) return false;
+
+	const authorization = request.headers.get("authorization");
+	if (!authorization?.startsWith("Bearer ")) return false;
+
+	return constantTimeEqual(
+		authorization.slice("Bearer ".length),
+		expectedToken,
+	);
+}
+
+/** Handles the authenticated internal debugging MCP endpoint. */
+export async function POST(request: NextRequest) {
+	if (!process.env.BACKEND_ACCESS_TOKEN) {
+		return NextResponse.json(
+			{ error: "Internal debugging is not configured" },
+			{ status: 503 },
+		);
+	}
+
+	if (!isAuthorized(request)) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	return handler(request);
+}

--- a/apps/main-site/src/instrumentation.ts
+++ b/apps/main-site/src/instrumentation.ts
@@ -1,3 +1,12 @@
-export function register() {}
+import * as Sentry from "@sentry/nextjs";
 
-export function onRequestError() {}
+export async function register() {
+	if (process.env.NEXT_RUNTIME === "nodejs") {
+		await import("../sentry.server.config");
+	}
+	if (process.env.NEXT_RUNTIME === "edge") {
+		await import("../sentry.edge.config");
+	}
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/apps/main-site/src/lib/mcp/convex-debug-tools.ts
+++ b/apps/main-site/src/lib/mcp/convex-debug-tools.ts
@@ -1,0 +1,563 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+type ConvexFunctionSpec = {
+	identifier?: string;
+	functionType?: "Query" | "Mutation" | "Action" | "HttpAction";
+	visibility?: { kind?: "public" | "internal" };
+	args?: unknown;
+	returns?: unknown;
+};
+
+type ConvexFunctionResponse = {
+	status: "success" | "error";
+	value?: unknown;
+	logLines?: unknown[];
+	errorMessage?: string;
+	errorData?: unknown;
+};
+
+type ConvexCredentials = {
+	deploymentUrl: string;
+	adminKey: string;
+	deploymentName: string | null;
+	deploymentType: string;
+};
+
+const convexArgsSchema = z
+	.record(z.string(), z.unknown())
+	.default({})
+	.optional()
+	.describe(
+		"Convex-encoded JSON arguments. Use Convex JSON markers such as {$integer: base64} for int64 values.",
+	);
+
+function toolResponse(value: unknown) {
+	return {
+		content: [
+			{
+				type: "text" as const,
+				text: JSON.stringify(value, null, 2),
+			},
+		],
+	};
+}
+
+function getConvexCredentials(): ConvexCredentials {
+	const deploymentUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+	const adminKey = process.env.CONVEX_DEPLOY_KEY;
+
+	if (!deploymentUrl || !adminKey) {
+		throw new Error(
+			"Convex internal debugging requires NEXT_PUBLIC_CONVEX_URL and CONVEX_DEPLOY_KEY",
+		);
+	}
+
+	const url = new URL(deploymentUrl);
+	if (url.protocol !== "https:" && url.protocol !== "http:") {
+		throw new Error("Convex deployment URL must use HTTP or HTTPS");
+	}
+
+	const keyPrefix = adminKey.split("|", 1)[0] ?? "";
+	const [deploymentType = "prod", deploymentName] = keyPrefix.split(":");
+
+	return {
+		deploymentUrl: url.toString().replace(/\/$/, ""),
+		adminKey,
+		deploymentName: deploymentName || null,
+		deploymentType,
+	};
+}
+
+async function convexFetch(path: string, init: RequestInit = {}) {
+	const { deploymentUrl, adminKey } = getConvexCredentials();
+	const headers = new Headers(init.headers);
+	headers.set("Authorization", `Convex ${adminKey}`);
+	if (!headers.has("Content-Type")) {
+		headers.set("Content-Type", "application/json");
+	}
+	headers.set("Convex-Client", "answer-overflow-internal-debugging");
+
+	const response = await fetch(new URL(path, deploymentUrl), {
+		...init,
+		headers,
+		cache: "no-store",
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`Convex HTTP ${response.status}: ${body.slice(0, 2000)}`);
+	}
+
+	return response;
+}
+
+function normalizeFunctionName(functionName: string): string {
+	if (functionName.startsWith("api.") || functionName.startsWith("internal.")) {
+		const parts = functionName.split(".");
+		if (parts.length < 3) {
+			throw new Error(`Invalid Convex function name: ${functionName}`);
+		}
+		const exportName = parts.pop();
+		return `${parts.slice(1).join("/")}:${exportName}`;
+	}
+
+	const withoutPrefix = functionName.replace(/^convex\//, "");
+	const [filePath = "", exportName = "default"] = withoutPrefix.split(":", 2);
+	const normalizedPath = filePath.replace(
+		/\.(?:ts|js|tsx|jsx|mts|mjs|cts|cjs)$/,
+		"",
+	);
+	return `${normalizedPath}:${exportName}`;
+}
+
+async function runConvexFunction(
+	functionName: string,
+	args: Record<string, unknown>,
+	componentPath?: string,
+) {
+	const normalizedFunctionName = normalizeFunctionName(functionName);
+	const response = await convexFetch("/api/function", {
+		method: "POST",
+		body: JSON.stringify({
+			path: normalizedFunctionName,
+			componentPath,
+			format: "convex_encoded_json",
+			args,
+		}),
+	});
+	const result = (await response.json()) as ConvexFunctionResponse;
+
+	if (result.status !== "success") {
+		throw new Error(
+			`Convex function ${normalizedFunctionName} failed: ${result.errorMessage ?? JSON.stringify(result)}`,
+		);
+	}
+
+	return {
+		functionName: normalizedFunctionName,
+		result: result.value,
+		logLines: result.logLines ?? [],
+	};
+}
+
+async function runConvexQuery(
+	functionName: string,
+	args: Record<string, unknown>,
+	componentPath?: string,
+) {
+	const normalizedFunctionName = normalizeFunctionName(functionName);
+	const response = await convexFetch("/api/query", {
+		method: "POST",
+		body: JSON.stringify({
+			path: normalizedFunctionName,
+			componentPath,
+			format: "convex_encoded_json",
+			args: [args],
+		}),
+	});
+	const result = (await response.json()) as ConvexFunctionResponse;
+
+	if (result.status !== "success") {
+		throw new Error(
+			`Convex query ${normalizedFunctionName} failed: ${result.errorMessage ?? JSON.stringify(result)}`,
+		);
+	}
+
+	return {
+		functionName: normalizedFunctionName,
+		result: result.value,
+		logLines: result.logLines ?? [],
+	};
+}
+
+async function getFunctionSpec(): Promise<ConvexFunctionSpec[]> {
+	const response = await runConvexQuery("_system/cli/modules:apiSpec", {});
+	if (!Array.isArray(response.result)) {
+		throw new Error("Convex returned an invalid function specification");
+	}
+	return response.result as ConvexFunctionSpec[];
+}
+
+async function getFunctionMetadata(functionName: string) {
+	const normalized = normalizeFunctionName(functionName);
+	const functions = await getFunctionSpec();
+	return functions.find(
+		(fn) =>
+			typeof fn.identifier === "string" &&
+			normalizeFunctionName(fn.identifier) === normalized,
+	);
+}
+
+async function runReadOnlyFunction(
+	functionName: string,
+	args: Record<string, unknown>,
+	componentPath?: string,
+) {
+	const metadata = await getFunctionMetadata(functionName);
+	if (!metadata) {
+		throw new Error(`Unknown Convex function: ${functionName}`);
+	}
+	if (metadata.functionType !== "Query") {
+		throw new Error(
+			`${functionName} is a ${metadata.functionType ?? "non-query"} function; use convex_run_function for mutating operations`,
+		);
+	}
+	return runConvexQuery(functionName, args, componentPath);
+}
+
+async function listTables() {
+	const [schemaResponse, shapesResponse] = await Promise.all([
+		runConvexQuery("_system/frontend/getSchemas", {}),
+		convexFetch("/api/shapes2").then((response) => response.json()),
+	]);
+
+	const schemaByTable = new Map<string, unknown>();
+	const schemaResult = schemaResponse.result as {
+		active?: string | null;
+	} | null;
+	if (schemaResult?.active) {
+		const activeSchema = JSON.parse(schemaResult.active) as {
+			tables?: Array<{ tableName?: string }>;
+		};
+		for (const table of activeSchema.tables ?? []) {
+			if (table.tableName) schemaByTable.set(table.tableName, table);
+		}
+	}
+
+	const shapes = shapesResponse as Record<string, unknown>;
+	const tableNames = Array.from(
+		new Set([...schemaByTable.keys(), ...Object.keys(shapes)]),
+	).sort();
+
+	return {
+		tables: Object.fromEntries(
+			tableNames.map((tableName) => [
+				tableName,
+				{
+					schema: schemaByTable.get(tableName) ?? null,
+					inferredSchema: shapes[tableName] ?? null,
+				},
+			]),
+		),
+	};
+}
+
+async function runOneOffQuery(query: string) {
+	const { adminKey } = getConvexCredentials();
+	const response = await convexFetch("/api/run_test_function", {
+		method: "POST",
+		body: JSON.stringify({
+			adminKey,
+			args: {},
+			bundle: { path: "internalDebugQuery.js", source: query },
+			format: "convex_encoded_json",
+		}),
+	});
+	const result = (await response.json()) as ConvexFunctionResponse;
+	if (result.status !== "success") {
+		throw new Error(
+			`Convex one-off query failed: ${result.errorMessage ?? JSON.stringify(result)}`,
+		);
+	}
+	return { result: result.value, logLines: result.logLines ?? [] };
+}
+
+async function listEnvironmentVariables(includeValues: boolean) {
+	const response = await runConvexQuery(
+		"_system/cli/queryEnvironmentVariables",
+		{},
+	);
+	const variables = Array.isArray(response.result) ? response.result : [];
+	return {
+		variables: variables.map((variable) => {
+			const entry = variable as { name?: string; value?: string };
+			return includeValues
+				? { name: entry.name, value: entry.value }
+				: { name: entry.name };
+		}),
+	};
+}
+
+/** Registers generic Convex deployment and dashboard tools. */
+export function registerConvexDebugTools(server: McpServer) {
+	server.registerTool(
+		"convex_deployment_status",
+		{
+			title: "Convex Deployment Status",
+			description:
+				"Describe the configured Convex deployment without returning its admin credential.",
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async () => {
+			const credentials = getConvexCredentials();
+			return toolResponse({
+				deploymentUrl: credentials.deploymentUrl,
+				deploymentName: credentials.deploymentName,
+				deploymentType: credentials.deploymentType,
+				dashboardUrl: credentials.deploymentName
+					? `https://dashboard.convex.dev/d/${credentials.deploymentName}`
+					: null,
+			});
+		},
+	);
+
+	server.registerTool(
+		"convex_function_spec",
+		{
+			title: "Convex Function Specification",
+			description:
+				"Discover live Convex functions and their argument, return, visibility, and operation metadata.",
+			inputSchema: {
+				search: z.string().max(500).optional(),
+				functionTypes: z
+					.array(z.enum(["Query", "Mutation", "Action", "HttpAction"]))
+					.optional(),
+				visibility: z.enum(["public", "internal"]).optional(),
+				limit: z.number().int().min(1).max(2000).default(500).optional(),
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ search, functionTypes, visibility, limit }) => {
+			const functions = await getFunctionSpec();
+			const normalizedSearch = search?.toLowerCase();
+			const filtered = functions.filter(
+				(fn) =>
+					(!normalizedSearch ||
+						JSON.stringify(fn).toLowerCase().includes(normalizedSearch)) &&
+					(!functionTypes?.length ||
+						(fn.functionType && functionTypes.includes(fn.functionType))) &&
+					(!visibility || fn.visibility?.kind === visibility),
+			);
+			return toolResponse({
+				totalFunctions: functions.length,
+				matchingFunctions: filtered.length,
+				functions: filtered.slice(0, limit ?? 500),
+			});
+		},
+	);
+
+	server.registerTool(
+		"convex_run_query",
+		{
+			title: "Run Convex Query",
+			description:
+				"Run any discovered Convex query, including internal queries, with admin authentication.",
+			inputSchema: {
+				functionName: z.string().min(1),
+				args: convexArgsSchema,
+				componentPath: z.string().optional(),
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ functionName, args, componentPath }) =>
+			toolResponse(
+				await runReadOnlyFunction(functionName, args ?? {}, componentPath),
+			),
+	);
+
+	server.registerTool(
+		"convex_run_function",
+		{
+			title: "Run Convex Function",
+			description:
+				"Run any discovered Convex query, mutation, or action with admin authentication. Inspect the live function specification first.",
+			inputSchema: {
+				functionName: z.string().min(1),
+				args: convexArgsSchema,
+				componentPath: z.string().optional(),
+			},
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: false,
+				openWorldHint: true,
+			},
+		},
+		async ({ functionName, args, componentPath }) =>
+			toolResponse(
+				await runConvexFunction(functionName, args ?? {}, componentPath),
+			),
+	);
+
+	server.registerTool(
+		"convex_run_readonly_query",
+		{
+			title: "Run One-Off Convex Query",
+			description:
+				"Execute a sandboxed one-off JavaScript query. It can read Convex data but cannot modify data or access the network.",
+			inputSchema: { query: z.string().min(1).max(100_000) },
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ query }) => toolResponse(await runOneOffQuery(query)),
+	);
+
+	server.registerTool(
+		"convex_tables",
+		{
+			title: "List Convex Tables",
+			description:
+				"List all Convex tables with declared and inferred schemas from the dashboard APIs.",
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async () => toolResponse(await listTables()),
+	);
+
+	server.registerTool(
+		"convex_table_data",
+		{
+			title: "Read Convex Table Data",
+			description:
+				"Read a page of raw Convex table data using the same system query as the Convex dashboard and CLI.",
+			inputSchema: {
+				tableName: z.string().min(1),
+				order: z.enum(["asc", "desc"]).default("desc").optional(),
+				cursor: z.string().nullable().optional(),
+				limit: z.number().int().min(1).max(1000).default(100).optional(),
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ tableName, order, cursor, limit }) =>
+			toolResponse(
+				await runConvexQuery("_system/cli/tableData", {
+					table: tableName,
+					order: order ?? "desc",
+					paginationOpts: {
+						numItems: limit ?? 100,
+						cursor: cursor ?? null,
+					},
+				}),
+			),
+	);
+
+	server.registerTool(
+		"convex_logs",
+		{
+			title: "Read Convex Logs",
+			description:
+				"Fetch a bounded chunk of recent Convex function execution logs, optionally filtered by text such as a request ID or function name.",
+			inputSchema: {
+				cursor: z.number().int().min(0).default(0).optional(),
+				status: z.enum(["all", "success", "failure"]).default("all").optional(),
+				search: z.string().max(1000).optional(),
+				entriesLimit: z.number().int().min(1).max(1000).default(100).optional(),
+				characterLimit: z
+					.number()
+					.int()
+					.min(1000)
+					.max(500_000)
+					.default(100_000)
+					.optional(),
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ cursor, status, search, entriesLimit, characterLimit }) => {
+			const response = await convexFetch(
+				`/api/stream_function_logs?cursor=${cursor ?? 0}`,
+			);
+			const result = (await response.json()) as {
+				entries?: unknown[];
+				newCursor?: number;
+			};
+			const normalizedSearch = search?.toLowerCase();
+			const matchingEntries = (result.entries ?? []).filter((entry) => {
+				const execution = entry as { kind?: string; error?: unknown };
+				const matchesStatus =
+					!status ||
+					status === "all" ||
+					(execution.kind === "Completion" &&
+						(status === "failure"
+							? execution.error !== null && execution.error !== undefined
+							: execution.error === null || execution.error === undefined));
+				return (
+					matchesStatus &&
+					(!normalizedSearch ||
+						JSON.stringify(entry).toLowerCase().includes(normalizedSearch))
+				);
+			});
+			const selectedEntries = matchingEntries.slice(-(entriesLimit ?? 100));
+			const maxCharacters = characterLimit ?? 100_000;
+			const boundedEntries: unknown[] = [];
+			let characters = 0;
+			for (const entry of selectedEntries.slice().reverse()) {
+				const serialized = JSON.stringify(entry);
+				if (characters + serialized.length > maxCharacters) break;
+				boundedEntries.push(entry);
+				characters += serialized.length;
+			}
+			boundedEntries.reverse();
+
+			return toolResponse({
+				entries: boundedEntries,
+				matchingEntries: matchingEntries.length,
+				returnedEntries: boundedEntries.length,
+				newCursor: result.newCursor ?? cursor ?? 0,
+			});
+		},
+	);
+
+	server.registerTool(
+		"convex_environment_variables",
+		{
+			title: "Inspect Convex Environment Variables",
+			description:
+				"List Convex deployment environment variables. Values are omitted unless includeValues is explicitly true.",
+			inputSchema: {
+				includeValues: z.boolean().default(false).optional(),
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ includeValues }) =>
+			toolResponse(await listEnvironmentVariables(includeValues ?? false)),
+	);
+
+	server.registerTool(
+		"convex_set_environment_variable",
+		{
+			title: "Set Convex Environment Variable",
+			description: "Set one environment variable on the Convex deployment.",
+			inputSchema: {
+				name: z.string().regex(/^[A-Za-z][A-Za-z0-9_]*$/),
+				value: z.string(),
+			},
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: true,
+				openWorldHint: false,
+			},
+		},
+		async ({ name, value }) => {
+			await convexFetch("/api/update_environment_variables", {
+				method: "POST",
+				body: JSON.stringify({ changes: [{ name, value }] }),
+			});
+			return toolResponse({ success: true, name });
+		},
+	);
+
+	server.registerTool(
+		"convex_remove_environment_variable",
+		{
+			title: "Remove Convex Environment Variable",
+			description:
+				"Remove one environment variable from the Convex deployment.",
+			inputSchema: {
+				name: z.string().regex(/^[A-Za-z][A-Za-z0-9_]*$/),
+			},
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: true,
+				openWorldHint: false,
+			},
+		},
+		async ({ name }) => {
+			await convexFetch("/api/update_environment_variables", {
+				method: "POST",
+				body: JSON.stringify({ changes: [{ name }] }),
+			});
+			return toolResponse({ success: true, name });
+		},
+	);
+}

--- a/apps/main-site/src/lib/mcp/internal-debug-tools.ts
+++ b/apps/main-site/src/lib/mcp/internal-debug-tools.ts
@@ -1,0 +1,439 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Database } from "@packages/database/database";
+import { Effect } from "effect";
+import { z } from "zod";
+import { runtime } from "@/lib/runtime";
+import { registerConvexDebugTools } from "./convex-debug-tools";
+
+const snowflakeSchema = z
+	.string()
+	.regex(/^\d+$/, "Expected a Discord snowflake ID");
+
+type AttachmentUrlSummary = {
+	host: string;
+	path: string;
+	expiresAt: string | null;
+	isDiscordSignedUrl: boolean;
+};
+
+type PrivacyPost = {
+	server: {
+		discordId: bigint;
+		name: string;
+	};
+	message: {
+		author?: {
+			id: bigint;
+			isAnonymous?: boolean;
+		} | null;
+	};
+};
+
+function summarizeAttachmentUrl(rawUrl: string): AttachmentUrlSummary {
+	try {
+		const url = new URL(rawUrl);
+		const expiryHex = url.searchParams.get("ex");
+		const expirySeconds = expiryHex
+			? Number.parseInt(expiryHex, 16)
+			: Number.NaN;
+
+		return {
+			host: url.host,
+			path: url.pathname,
+			expiresAt: Number.isFinite(expirySeconds)
+				? new Date(expirySeconds * 1000).toISOString()
+				: null,
+			isDiscordSignedUrl:
+				url.hostname === "cdn.discordapp.com" ||
+				url.hostname === "media.discordapp.net",
+		};
+	} catch {
+		return {
+			host: "invalid-url",
+			path: rawUrl,
+			expiresAt: null,
+			isDiscordSignedUrl: false,
+		};
+	}
+}
+
+function toolResponse(value: unknown) {
+	return {
+		content: [
+			{
+				type: "text" as const,
+				text: JSON.stringify(
+					value,
+					(_key, item) => (typeof item === "bigint" ? item.toString() : item),
+					2,
+				),
+			},
+		],
+	};
+}
+
+async function inspectMessageState(messageId: bigint) {
+	return Effect.gen(function* () {
+		const database = yield* Database;
+		const { rawMessage, header } = yield* Effect.all({
+			rawMessage: database.private.messages.getMessageById({ id: messageId }),
+			header: database.public.messages.getMessagePageHeaderData({ messageId }),
+		});
+
+		if (!rawMessage) {
+			return {
+				messageId: messageId.toString(),
+				exists: false,
+				publiclyResolvable: header !== null,
+			};
+		}
+
+		const { server, serverPreferences, authorServerSettings } =
+			yield* Effect.all({
+				server: database.private.servers.getServerByDiscordId({
+					discordId: rawMessage.serverId,
+				}),
+				serverPreferences:
+					database.private.server_preferences.getServerPreferencesByServerId({
+						serverId: rawMessage.serverId,
+					}),
+				authorServerSettings:
+					database.private.user_server_settings.findUserServerSettingsById({
+						userId: rawMessage.authorId,
+						serverId: rawMessage.serverId,
+					}),
+			});
+
+		const snapshotAttachments = (rawMessage.snapshot?.attachments ?? []).map(
+			(attachment) => ({
+				id: attachment.id.toString(),
+				filename: attachment.filename,
+				contentType: attachment.contentType ?? null,
+				url: summarizeAttachmentUrl(attachment.url),
+			}),
+		);
+
+		return {
+			messageId: messageId.toString(),
+			exists: true,
+			publiclyResolvable: header !== null,
+			message: {
+				authorId: rawMessage.authorId.toString(),
+				serverId: rawMessage.serverId.toString(),
+				channelId: rawMessage.channelId.toString(),
+				parentChannelId: rawMessage.parentChannelId?.toString() ?? null,
+				childThreadId: rawMessage.childThreadId?.toString() ?? null,
+				questionId: rawMessage.questionId?.toString() ?? null,
+				referenceId: rawMessage.referenceId?.toString() ?? null,
+				type: rawMessage.type ?? null,
+				flags: rawMessage.flags ?? null,
+				hasSnapshot: rawMessage.snapshot !== undefined,
+				snapshotAttachmentCount: snapshotAttachments.length,
+			},
+			snapshotAttachments,
+			server: server
+				? {
+						id: server.discordId.toString(),
+						name: server.name,
+						kickedTime: server.kickedTime ?? null,
+					}
+				: null,
+			serverPreferences: serverPreferences
+				? {
+						considerAllMessagesPublicEnabled:
+							serverPreferences.considerAllMessagesPublicEnabled ?? false,
+						anonymizeMessagesEnabled:
+							serverPreferences.anonymizeMessagesEnabled ?? false,
+						readTheRulesConsentEnabled:
+							serverPreferences.readTheRulesConsentEnabled ?? false,
+					}
+				: null,
+			authorServerSettings: authorServerSettings
+				? {
+						permissions: authorServerSettings.permissions,
+						roleIds:
+							authorServerSettings.roleIds?.map((id) => id.toString()) ?? [],
+						canPubliclyDisplayMessages:
+							authorServerSettings.canPubliclyDisplayMessages,
+						messageIndexingDisabled:
+							authorServerSettings.messageIndexingDisabled,
+					}
+				: null,
+		};
+	}).pipe(runtime.runPromise);
+}
+
+async function inspectThreadMedia(threadId: bigint) {
+	return Effect.gen(function* () {
+		const database = yield* Database;
+		const header = yield* database.public.messages.getMessagePageHeaderData({
+			messageId: threadId,
+		});
+
+		if (!header) {
+			return { threadId: threadId.toString(), exists: false };
+		}
+
+		const channelId = header.threadId ?? header.canonicalId;
+		const messages = yield* database.public.messages.getMessages({
+			channelId,
+			after: 0n,
+			paginationOpts: { numItems: 100, cursor: null },
+		});
+
+		const forwardedSnapshots = messages.page.flatMap((entry) => {
+			const snapshot = entry.message.snapshot;
+			if (!snapshot) return [];
+
+			return [
+				{
+					messageId: entry.message.id.toString(),
+					attachmentCount: snapshot.attachments?.length ?? 0,
+					attachments: (snapshot.attachments ?? []).map((attachment) => ({
+						id: attachment.id.toString(),
+						filename: attachment.filename,
+						contentType: attachment.contentType ?? null,
+						url: summarizeAttachmentUrl(attachment.url),
+					})),
+				},
+			];
+		});
+
+		return {
+			threadId: threadId.toString(),
+			exists: true,
+			canonicalId: header.canonicalId.toString(),
+			messageCountInspected: messages.page.length,
+			isComplete: messages.isDone,
+			forwardedSnapshots,
+			expiringDiscordAttachmentCount: forwardedSnapshots.reduce(
+				(total, snapshot) =>
+					total +
+					snapshot.attachments.filter(
+						(attachment) => attachment.url.isDiscordSignedUrl,
+					).length,
+				0,
+			),
+		};
+	}).pipe(runtime.runPromise);
+}
+
+async function inspectUserPrivacy(userId: bigint, maxPosts: number) {
+	return Effect.gen(function* () {
+		const database = yield* Database;
+		const header =
+			yield* database.public.discord_accounts.getUserPageHeaderData({
+				userId,
+			});
+
+		const posts: PrivacyPost[] = [];
+		let cursor: string | null = null;
+		let isDone = false;
+
+		while (!isDone && posts.length < maxPosts) {
+			const pageResult: {
+				page: PrivacyPost[];
+				continueCursor: string;
+				isDone: boolean;
+			} = yield* database.public.discord_accounts.getUserPosts({
+				userId,
+				paginationOpts: {
+					numItems: Math.min(100, maxPosts - posts.length),
+					cursor,
+				},
+			});
+			posts.push(...pageResult.page);
+			cursor = pageResult.continueCursor;
+			isDone = pageResult.isDone;
+		}
+
+		const serverSummaries = new Map<
+			string,
+			{
+				serverId: bigint;
+				serverName: string;
+				messageCount: number;
+				anonymousCount: number;
+				identifiedCount: number;
+				publicAuthorIds: Set<string>;
+			}
+		>();
+
+		for (const post of posts) {
+			const serverId = post.server.discordId;
+			const key = serverId.toString();
+			const summary = serverSummaries.get(key) ?? {
+				serverId,
+				serverName: post.server.name,
+				messageCount: 0,
+				anonymousCount: 0,
+				identifiedCount: 0,
+				publicAuthorIds: new Set<string>(),
+			};
+
+			summary.messageCount += 1;
+			if (post.message.author?.isAnonymous) {
+				summary.anonymousCount += 1;
+			} else {
+				summary.identifiedCount += 1;
+			}
+			if (post.message.author) {
+				summary.publicAuthorIds.add(post.message.author.id.toString());
+			}
+			serverSummaries.set(key, summary);
+		}
+
+		const perServer = yield* Effect.forEach(
+			Array.from(serverSummaries.values()),
+			(summary) =>
+				Effect.all({
+					settings:
+						database.private.user_server_settings.findUserServerSettingsById({
+							userId,
+							serverId: summary.serverId,
+						}),
+					preferences:
+						database.private.server_preferences.getServerPreferencesByServerId({
+							serverId: summary.serverId,
+						}),
+				}).pipe(
+					Effect.map(({ settings, preferences }) => ({
+						serverId: summary.serverId.toString(),
+						serverName: summary.serverName,
+						messageCount: summary.messageCount,
+						anonymousCount: summary.anonymousCount,
+						identifiedCount: summary.identifiedCount,
+						publicAuthorIds: Array.from(summary.publicAuthorIds),
+						serverAnonymizationEnabled:
+							preferences?.anonymizeMessagesEnabled ?? false,
+						considerAllMessagesPublicEnabled:
+							preferences?.considerAllMessagesPublicEnabled ?? false,
+						canPubliclyDisplayMessages:
+							settings?.canPubliclyDisplayMessages ?? false,
+						messageIndexingDisabled: settings?.messageIndexingDisabled ?? false,
+					})),
+				),
+			{ concurrency: 8 },
+		);
+
+		const profilePublic = header !== null;
+		const hasAnonymousPosts = perServer.some(
+			(server) => server.anonymousCount > 0,
+		);
+		const hasIdentifiedPosts = perServer.some(
+			(server) => server.identifiedCount > 0,
+		);
+
+		return {
+			userId: userId.toString(),
+			profilePublic,
+			profileIdentity: header?.user ?? null,
+			postsInspected: posts.length,
+			isComplete: isDone,
+			crossServerLinkabilityDetected:
+				profilePublic && hasAnonymousPosts && hasIdentifiedPosts,
+			servers: perServer,
+		};
+	}).pipe(runtime.runPromise);
+}
+
+async function inspectSolutionState(questionId: bigint, solutionId: bigint) {
+	return Effect.gen(function* () {
+		const database = yield* Database;
+		const { question, solution } = yield* Effect.all({
+			question: database.private.messages.getMessageById({ id: questionId }),
+			solution: database.private.messages.getMessageById({ id: solutionId }),
+		});
+
+		return {
+			questionId: questionId.toString(),
+			solutionId: solutionId.toString(),
+			questionExists: question !== null,
+			solutionExists: solution !== null,
+			sameServer:
+				question && solution ? question.serverId === solution.serverId : null,
+			sameChannel:
+				question && solution ? question.channelId === solution.channelId : null,
+			solutionQuestionId: solution?.questionId?.toString() ?? null,
+			question: question
+				? {
+						serverId: question.serverId.toString(),
+						channelId: question.channelId.toString(),
+						parentChannelId: question.parentChannelId?.toString() ?? null,
+					}
+				: null,
+			solution: solution
+				? {
+						serverId: solution.serverId.toString(),
+						channelId: solution.channelId.toString(),
+						parentChannelId: solution.parentChannelId?.toString() ?? null,
+					}
+				: null,
+		};
+	}).pipe(runtime.runPromise);
+}
+
+/** Registers tools for internal Answer Overflow debugging. */
+export function registerInternalDebugTools(server: McpServer) {
+	registerConvexDebugTools(server);
+
+	server.registerTool(
+		"inspect_message_state",
+		{
+			title: "Inspect Message State",
+			description:
+				"Inspect raw and public Convex state for one Discord message, including privacy settings and forwarded snapshot attachment expiry metadata.",
+			inputSchema: { messageId: snowflakeSchema },
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ messageId }) =>
+			toolResponse(await inspectMessageState(BigInt(messageId))),
+	);
+
+	server.registerTool(
+		"inspect_thread_media",
+		{
+			title: "Inspect Thread Media",
+			description:
+				"Inspect forwarded message snapshots in a thread and identify media URLs that still depend on expiring Discord signatures.",
+			inputSchema: { threadId: snowflakeSchema },
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ threadId }) =>
+			toolResponse(await inspectThreadMedia(BigInt(threadId))),
+	);
+
+	server.registerTool(
+		"inspect_user_privacy",
+		{
+			title: "Inspect User Privacy",
+			description:
+				"Inspect how one Discord user's public and anonymized posts are exposed across servers, without returning API keys or message bodies.",
+			inputSchema: {
+				userId: snowflakeSchema,
+				maxPosts: z.number().int().min(1).max(500).default(250).optional(),
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ userId, maxPosts }) =>
+			toolResponse(await inspectUserPrivacy(BigInt(userId), maxPosts ?? 250)),
+	);
+
+	server.registerTool(
+		"inspect_solution_state",
+		{
+			title: "Inspect Solution State",
+			description:
+				"Check whether a question and proposed solution message are indexed and compatible before investigating a mark-solution failure.",
+			inputSchema: {
+				questionId: snowflakeSchema,
+				solutionId: snowflakeSchema,
+			},
+			annotations: { readOnlyHint: true, openWorldHint: false },
+		},
+		async ({ questionId, solutionId }) =>
+			toolResponse(
+				await inspectSolutionState(BigInt(questionId), BigInt(solutionId)),
+			),
+	);
+}


### PR DESCRIPTION
Adds an authenticated internal MCP endpoint with issue-specific inspectors and live Convex function, data, log, and environment tools. It also enables server request error capture for internal debugging.

Validated with the main-site typecheck, Biome, production build, and mcporter calls against the scoped endpoint.
