### PR TITLE
Hide anonymized posts from profiles

### DIFF
--- a/packages/database/convex/public/discord_accounts.test.ts
+++ b/packages/database/convex/public/discord_accounts.test.ts
@@ -235,5 +235,66 @@ describe("public/discord_accounts", () => {
 				);
 			}).pipe(Effect.provide(DatabaseTestLayer)),
 		);
+
+		it.scoped("should keep a cursor when an anonymized page is empty", () =>
+			Effect.gen(function* () {
+				const database = yield* Database;
+				const identifiedFixture = yield* createForumThreadWithReplies();
+				yield* identifiedFixture.addRootMessage();
+
+				const anonymousServer = yield* createServer();
+				const anonymousForum = yield* createChannel(anonymousServer.discordId, {
+					type: 15,
+				});
+				yield* enableChannelIndexing(anonymousForum.id);
+				yield* database.private.server_preferences.upsertServerPreferences({
+					serverId: anonymousServer.discordId,
+					plan: "FREE",
+					considerAllMessagesPublicEnabled: true,
+					anonymizeMessagesEnabled: true,
+				});
+
+				for (let count = 0; count < 2; count += 1) {
+					const thread = yield* createChannel(anonymousServer.discordId, {
+						type: 11,
+						parentId: anonymousForum.id,
+					});
+					yield* createMessage(
+						{
+							authorId: identifiedFixture.author.id,
+							serverId: anonymousServer.discordId,
+							channelId: thread.id,
+						},
+						{
+							id: thread.id,
+							parentChannelId: anonymousForum.id,
+						},
+					);
+				}
+
+				const firstPage = yield* database.public.discord_accounts.getUserPosts({
+					userId: identifiedFixture.author.id,
+					paginationOpts: { numItems: 2, cursor: null },
+				});
+
+				expect(firstPage.page).toEqual([]);
+				expect(firstPage.isDone).toBe(false);
+
+				const secondPage = yield* database.public.discord_accounts.getUserPosts(
+					{
+						userId: identifiedFixture.author.id,
+						paginationOpts: {
+							numItems: 2,
+							cursor: firstPage.continueCursor,
+						},
+					},
+				);
+
+				expect(secondPage.page).toHaveLength(1);
+				expect(secondPage.page[0]?.server.discordId).toBe(
+					identifiedFixture.server.discordId,
+				);
+			}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
 	});
 });

--- a/packages/database/convex/public/discord_accounts.test.ts
+++ b/packages/database/convex/public/discord_accounts.test.ts
@@ -4,8 +4,11 @@ import { Database } from "../../src/database";
 import { DatabaseTestLayer } from "../../src/database-test";
 import {
 	createAuthor,
+	createChannel,
 	createForumThreadWithReplies,
+	createMessage,
 	createServer,
+	enableChannelIndexing,
 	makeMessagesPublic,
 } from "../../src/test";
 
@@ -185,6 +188,51 @@ describe("public/discord_accounts", () => {
 				});
 
 				expect(result.page).toEqual([]);
+			}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
+
+		it.scoped("should not link anonymized posts from a real user profile", () =>
+			Effect.gen(function* () {
+				const database = yield* Database;
+				const publicFixture = yield* createForumThreadWithReplies();
+				yield* publicFixture.addRootMessage();
+
+				const anonymousServer = yield* createServer();
+				const anonymousForum = yield* createChannel(anonymousServer.discordId, {
+					type: 15,
+				});
+				const anonymousThread = yield* createChannel(
+					anonymousServer.discordId,
+					{ type: 11, parentId: anonymousForum.id },
+				);
+				yield* enableChannelIndexing(anonymousForum.id);
+				yield* database.private.server_preferences.upsertServerPreferences({
+					serverId: anonymousServer.discordId,
+					plan: "FREE",
+					considerAllMessagesPublicEnabled: true,
+					anonymizeMessagesEnabled: true,
+				});
+				yield* createMessage(
+					{
+						authorId: publicFixture.author.id,
+						serverId: anonymousServer.discordId,
+						channelId: anonymousThread.id,
+					},
+					{
+						id: anonymousThread.id,
+						parentChannelId: anonymousForum.id,
+					},
+				);
+
+				const result = yield* database.public.discord_accounts.getUserPosts({
+					userId: publicFixture.author.id,
+					paginationOpts: { numItems: 10, cursor: null },
+				});
+
+				expect(result.page).toHaveLength(1);
+				expect(result.page[0]?.server.discordId).toBe(
+					publicFixture.server.discordId,
+				);
 			}).pipe(Effect.provide(DatabaseTestLayer)),
 		);
 	});

--- a/packages/database/convex/public/discord_accounts.test.ts
+++ b/packages/database/convex/public/discord_accounts.test.ts
@@ -240,7 +240,18 @@ describe("public/discord_accounts", () => {
 			Effect.gen(function* () {
 				const database = yield* Database;
 				const identifiedFixture = yield* createForumThreadWithReplies();
-				yield* identifiedFixture.addRootMessage();
+				yield* createMessage(
+					{
+						authorId: identifiedFixture.author.id,
+						serverId: identifiedFixture.server.discordId,
+						channelId: identifiedFixture.thread.id,
+					},
+					{
+						id: identifiedFixture.thread.id,
+						parentChannelId: identifiedFixture.forum.id,
+						childThreadId: 1n,
+					},
+				);
 
 				const anonymousServer = yield* createServer();
 				const anonymousForum = yield* createChannel(anonymousServer.discordId, {
@@ -268,6 +279,7 @@ describe("public/discord_accounts", () => {
 						{
 							id: thread.id,
 							parentChannelId: anonymousForum.id,
+							childThreadId: 3n - BigInt(count),
 						},
 					);
 				}

--- a/packages/database/convex/public/discord_accounts.ts
+++ b/packages/database/convex/public/discord_accounts.ts
@@ -31,9 +31,12 @@ export const getUserPosts = publicQuery({
 			ctx,
 			filteredMessages,
 		);
+		const identifiedPosts = enrichedPosts.filter(
+			(post) => !post.message.author?.isAnonymous,
+		);
 
 		return {
-			page: enrichedPosts,
+			page: identifiedPosts,
 			isDone: paginatedResult.isDone,
 			continueCursor: paginatedResult.continueCursor,
 		};

--- a/packages/ui/src/components/snapshot-infinite-list.tsx
+++ b/packages/ui/src/components/snapshot-infinite-list.tsx
@@ -67,6 +67,7 @@ export function SnapshotInfiniteList<Item>({
 }: SnapshotInfiniteListProps<Item>) {
 	const generationRef = useRef(0);
 	const lastLoadedLength = useRef(0);
+	const lastAutoAdvancedCursor = useRef<string | null>(null);
 	const [pages, setPages] = useState<Array<SnapshotPage<Item>>>(() =>
 		initialData ? [initialData] : [],
 	);
@@ -129,6 +130,7 @@ export function SnapshotInfiniteList<Item>({
 		generationRef.current += 1;
 		const generation = generationRef.current;
 		lastLoadedLength.current = 0;
+		lastAutoAdvancedCursor.current = null;
 		setError(null);
 
 		if (initialData) {
@@ -158,6 +160,26 @@ export function SnapshotInfiniteList<Item>({
 	const results = filterResults ? filterResults(rawResults) : rawResults;
 
 	const canLoadMore = !isLoadingFirstPage && !isLoadingMore && !isDone;
+
+	useEffect(() => {
+		if (
+			!canLoadMore ||
+			continueCursor === null ||
+			results.length > 0 ||
+			lastAutoAdvancedCursor.current === continueCursor
+		) {
+			return;
+		}
+
+		lastAutoAdvancedCursor.current = continueCursor;
+		setIsLoadingMore(true);
+		void fetchPage({
+			cursor: continueCursor,
+			numItems: pageSize,
+			append: true,
+			generation: generationRef.current,
+		});
+	}, [canLoadMore, continueCursor, fetchPage, pageSize, results.length]);
 
 	const handleRangeChanged = useCallback(
 		(range: { startIndex: number; endIndex: number }) => {


### PR DESCRIPTION
Keeps anonymized posts out of real user profile histories. Adds coverage for mixed privacy settings across servers.