### PR TITLE
Retry missing thread starter messages

### DIFF
--- a/apps/discord-bot/src/services/indexing.test.ts
+++ b/apps/discord-bot/src/services/indexing.test.ts
@@ -1,0 +1,35 @@
+import type { Message } from "discord.js";
+import { describe, expect, it } from "vitest";
+import { includeThreadStarter } from "./indexing";
+
+function message(id: string): Message {
+	return { id } as Message;
+}
+
+describe("includeThreadStarter", () => {
+	it("adds a missing starter in snowflake order", () => {
+		const result = includeThreadStarter(
+			[message("100000000000000003"), message("100000000000000005")],
+			message("100000000000000001"),
+		);
+
+		expect(result.map((item) => item.id)).toEqual([
+			"100000000000000001",
+			"100000000000000003",
+			"100000000000000005",
+		]);
+	});
+
+	it("does not duplicate an existing starter", () => {
+		const starter = message("100000000000000001");
+		const messages = [starter, message("100000000000000003")];
+
+		expect(includeThreadStarter(messages, starter)).toBe(messages);
+	});
+
+	it("leaves messages unchanged when Discord has no starter", () => {
+		const messages = [message("100000000000000003")];
+
+		expect(includeThreadStarter(messages, null)).toBe(messages);
+	});
+});

--- a/apps/discord-bot/src/services/indexing.ts
+++ b/apps/discord-bot/src/services/indexing.ts
@@ -303,6 +303,51 @@ function fetchChannelMessages(
 	);
 }
 
+export function includeThreadStarter(
+	messages: Message[],
+	starterMessage: Message | null,
+): Message[] {
+	if (
+		!starterMessage ||
+		messages.some((message) => message.id === starterMessage.id)
+	) {
+		return messages;
+	}
+
+	return Arr.sort([...messages, starterMessage], sortMessagesByIdAsc);
+}
+
+function fetchThreadMessages(
+	thread: AnyThreadChannel,
+	lastIndexedSnowflake?: bigint | null,
+) {
+	return Effect.gen(function* () {
+		const discord = yield* Discord;
+		const messages = yield* fetchChannelMessages(
+			thread.id,
+			thread.name,
+			lastIndexedSnowflake?.toString() ?? undefined,
+		);
+
+		if (messages.some((message) => message.id === thread.id)) {
+			return messages;
+		}
+
+		const starterMessage = yield* discord
+			.callClient(() => thread.fetchStarterMessage())
+			.pipe(
+				catchAllWithReport((error) =>
+					Console.warn(
+						`Failed to fetch starter message for thread ${thread.name} (${thread.id}):`,
+						error,
+					).pipe(Effect.as(null)),
+				),
+			);
+
+		return includeThreadStarter(messages, starterMessage);
+	});
+}
+
 function fetchForumThreads(
 	forumChannelId: string,
 	forumChannelName: string,
@@ -677,10 +722,9 @@ function indexThread(
 	return Effect.gen(function* () {
 		yield* syncChannel(thread);
 
-		const threadMessages = yield* fetchChannelMessages(
-			thread.id,
-			thread.name,
-			lastIndexedSnowflake?.toString() ?? undefined,
+		const threadMessages = yield* fetchThreadMessages(
+			thread,
+			lastIndexedSnowflake,
 		);
 		yield* storeMessages(
 			threadMessages,


### PR DESCRIPTION
Fetches a thread starter separately when an incremental indexing page does not contain it. Adds focused coverage for insertion and deduplication.