### PR TITLE
Handle unindexed solution messages

### DIFF
--- a/apps/main-site/src/app/(main-site)/api/handlers/messages.ts
+++ b/apps/main-site/src/app/(main-site)/api/handlers/messages.ts
@@ -43,6 +43,29 @@ export async function handleMarkSolution(args: {
 			},
 		);
 
+		if (trackingPayload && "error" in trackingPayload) {
+			switch (trackingPayload.error) {
+				case "QUESTION_NOT_FOUND":
+					return {
+						success: false,
+						status: 404,
+						error: "Question message is not indexed",
+					};
+				case "SOLUTION_NOT_FOUND":
+					return {
+						success: false,
+						status: 404,
+						error: "Solution message is not indexed",
+					};
+				case "SOLUTION_SERVER_MISMATCH":
+					return {
+						success: false,
+						status: 400,
+						error: "Solution message does not belong to the same server",
+					};
+			}
+		}
+
 		if (trackingPayload) {
 			try {
 				await trackSolvedQuestionFromApi(trackingPayload);

--- a/packages/database/convex/api/messages.test.ts
+++ b/packages/database/convex/api/messages.test.ts
@@ -35,12 +35,71 @@ async function hashApiKey(key: string): Promise<string> {
 	return base64UrlEncode(hashBuffer);
 }
 
+function createApiCaller(apiCallerId: bigint) {
+	return Effect.gen(function* () {
+		const convexClient = yield* ConvexClientTest;
+		const { client } = convexClient;
+		const rawApiKey = `user_test_solution_key_${apiCallerId.toString()}`;
+		const hashedApiKey = yield* Effect.tryPromise(() => hashApiKey(rawApiKey));
+		const now = Date.now();
+
+		const createdUser = yield* Effect.tryPromise(() =>
+			client.mutation(components.betterAuth.adapter.create, {
+				input: {
+					model: "user",
+					data: {
+						name: "API User",
+						email: `api-user-${apiCallerId.toString()}@example.com`,
+						emailVerified: true,
+						createdAt: now,
+						updatedAt: now,
+						userId: null,
+					},
+				},
+			}),
+		);
+		const betterAuthUserId = String(
+			createdUser.id ?? createdUser._id ?? "missing-user-id",
+		);
+
+		yield* Effect.tryPromise(() =>
+			client.mutation(components.betterAuth.adapter.create, {
+				input: {
+					model: "account",
+					data: {
+						accountId: apiCallerId.toString(),
+						providerId: "discord",
+						userId: betterAuthUserId,
+						createdAt: now,
+						updatedAt: now,
+					},
+				},
+			}),
+		);
+
+		yield* Effect.tryPromise(() =>
+			client.mutation(components.betterAuth.adapter.create, {
+				input: {
+					model: "apikey",
+					data: {
+						key: hashedApiKey,
+						userId: betterAuthUserId,
+						createdAt: now,
+						updatedAt: now,
+						enabled: true,
+					},
+				},
+			}),
+		);
+
+		return { client, rawApiKey };
+	});
+}
+
 describe("api.messages.updateSolution", () => {
 	it.scoped("returns tracking payload and ignores idempotent replays", () =>
 		Effect.gen(function* () {
 			const database = yield* Database;
-			const convexClient = yield* ConvexClientTest;
-			const { client } = convexClient;
 
 			const server = yield* createServer();
 			const forum = yield* createChannel(server.discordId, { type: 15 });
@@ -94,60 +153,7 @@ describe("api.messages.updateSolution", () => {
 				},
 			});
 
-			const rawApiKey = "user_test_solution_key";
-			const hashedApiKey = yield* Effect.tryPromise(() =>
-				hashApiKey(rawApiKey),
-			);
-			const now = Date.now();
-
-			const createdUser = yield* Effect.tryPromise(() =>
-				client.mutation(components.betterAuth.adapter.create, {
-					input: {
-						model: "user",
-						data: {
-							name: "API User",
-							email: "api-user@example.com",
-							emailVerified: true,
-							createdAt: now,
-							updatedAt: now,
-							userId: null,
-						},
-					},
-				}),
-			);
-			const betterAuthUserId = String(
-				createdUser.id ?? createdUser._id ?? "missing-user-id",
-			);
-
-			yield* Effect.tryPromise(() =>
-				client.mutation(components.betterAuth.adapter.create, {
-					input: {
-						model: "account",
-						data: {
-							accountId: apiCaller.id.toString(),
-							providerId: "discord",
-							userId: betterAuthUserId,
-							createdAt: now,
-							updatedAt: now,
-						},
-					},
-				}),
-			);
-
-			yield* Effect.tryPromise(() =>
-				client.mutation(components.betterAuth.adapter.create, {
-					input: {
-						model: "apikey",
-						data: {
-							key: hashedApiKey,
-							userId: betterAuthUserId,
-							createdAt: now,
-							updatedAt: now,
-							enabled: true,
-						},
-					},
-				}),
-			);
+			const { client, rawApiKey } = yield* createApiCaller(apiCaller.id);
 
 			const firstResult = yield* Effect.tryPromise(() =>
 				client.mutation(api.api.messages.updateSolution, {
@@ -157,12 +163,14 @@ describe("api.messages.updateSolution", () => {
 				}),
 			);
 
-			expect(firstResult).not.toBeNull();
-			expect(firstResult?.channel.id).toBe(forum.id.toString());
-			expect(firstResult?.thread.id).toBe(thread.id.toString());
-			expect(firstResult?.questionSolver.id).toBe(answerAuthor.id.toString());
-			expect(firstResult?.markAsSolver.id).toBe(apiCaller.id.toString());
-			expect(firstResult?.accountId).toBe(answerAuthor.id.toString());
+			if (!firstResult || "error" in firstResult) {
+				throw new Error("Expected a solved-question tracking payload");
+			}
+			expect(firstResult.channel.id).toBe(forum.id.toString());
+			expect(firstResult.thread.id).toBe(thread.id.toString());
+			expect(firstResult.questionSolver.id).toBe(answerAuthor.id.toString());
+			expect(firstResult.markAsSolver.id).toBe(apiCaller.id.toString());
+			expect(firstResult.accountId).toBe(answerAuthor.id.toString());
 
 			const storedAnswer = yield* database.private.messages.getMessageById(
 				{ id: answer.id },
@@ -180,5 +188,87 @@ describe("api.messages.updateSolution", () => {
 
 			expect(secondResult).toBeNull();
 		}).pipe(Effect.provide(DatabaseTestLayer)),
+	);
+
+	it.scoped("returns a typed result when the question is not indexed", () =>
+		Effect.gen(function* () {
+			const apiCaller = yield* createAuthor();
+			const { client, rawApiKey } = yield* createApiCaller(apiCaller.id);
+
+			const result = yield* Effect.tryPromise(() =>
+				client.mutation(api.api.messages.updateSolution, {
+					messageId: 100000000000000001n,
+					solutionId: null,
+					apiKey: rawApiKey,
+				}),
+			);
+
+			expect(result).toEqual({ error: "QUESTION_NOT_FOUND" });
+		}).pipe(Effect.provide(DatabaseTestLayer)),
+	);
+
+	it.scoped(
+		"returns a typed result without clearing the current solution when the replacement is not indexed",
+		() =>
+			Effect.gen(function* () {
+				const database = yield* Database;
+				const server = yield* createServer();
+				const forum = yield* createChannel(server.discordId, { type: 15 });
+				const thread = yield* createChannel(server.discordId, {
+					type: 11,
+					parentId: forum.id,
+				});
+				const questionAuthor = yield* createAuthor();
+				const answerAuthor = yield* createAuthor();
+				const apiCaller = yield* createAuthor();
+
+				const question = yield* createMessage(
+					{
+						authorId: questionAuthor.id,
+						serverId: server.discordId,
+						channelId: thread.id,
+					},
+					{ id: thread.id, parentChannelId: forum.id },
+				);
+				const currentSolution = yield* createMessage(
+					{
+						authorId: answerAuthor.id,
+						serverId: server.discordId,
+						channelId: thread.id,
+					},
+					{ id: thread.id + 1n, parentChannelId: forum.id },
+				);
+
+				yield* database.private.messages.markMessageAsSolution({
+					solutionMessageId: currentSolution.id,
+					questionMessageId: question.id,
+				});
+				yield* database.private.user_server_settings.upsertUserServerSettings({
+					settings: {
+						serverId: server.discordId,
+						userId: apiCaller.id,
+						permissions: ADMINISTRATOR,
+						roleIds: [],
+						canPubliclyDisplayMessages: true,
+						messageIndexingDisabled: false,
+						apiCallsUsed: 0,
+					},
+				});
+				const { client, rawApiKey } = yield* createApiCaller(apiCaller.id);
+
+				const result = yield* Effect.tryPromise(() =>
+					client.mutation(api.api.messages.updateSolution, {
+						messageId: question.id,
+						solutionId: thread.id + 2n,
+						apiKey: rawApiKey,
+					}),
+				);
+
+				expect(result).toEqual({ error: "SOLUTION_NOT_FOUND" });
+				const storedSolution = yield* database.private.messages.getMessageById({
+					id: currentSolution.id,
+				});
+				expect(storedSolution?.questionId).toBe(question.id);
+			}).pipe(Effect.provide(DatabaseTestLayer)),
 	);
 });

--- a/packages/database/convex/api/messages.ts
+++ b/packages/database/convex/api/messages.ts
@@ -61,6 +61,14 @@ const solvedQuestionTrackingPayloadValidator = v.object({
 	timeToSolveInMs: v.number(),
 });
 
+const updateSolutionErrorValidator = v.object({
+	error: v.union(
+		v.literal("QUESTION_NOT_FOUND"),
+		v.literal("SOLUTION_NOT_FOUND"),
+		v.literal("SOLUTION_SERVER_MISMATCH"),
+	),
+});
+
 export type SolvedQuestionTrackingPayload = Infer<
 	typeof solvedQuestionTrackingPayloadValidator
 >;
@@ -108,7 +116,11 @@ export const updateSolution = apiKeyMutation({
 		messageId: v.int64(),
 		solutionId: v.union(v.int64(), v.null()),
 	},
-	returns: v.union(v.null(), solvedQuestionTrackingPayloadValidator),
+	returns: v.union(
+		v.null(),
+		solvedQuestionTrackingPayloadValidator,
+		updateSolutionErrorValidator,
+	),
 	handler: async (ctx, args) => {
 		const message = await getOneFrom(
 			ctx.db,
@@ -118,7 +130,7 @@ export const updateSolution = apiKeyMutation({
 			"id",
 		);
 		if (!message) {
-			throw new Error("Message not found");
+			return { error: "QUESTION_NOT_FOUND" as const };
 		}
 
 		const permissionResult = await checkGuildManagerPermissions(
@@ -128,6 +140,25 @@ export const updateSolution = apiKeyMutation({
 		);
 		assertGuildManagerPermission(permissionResult);
 
+		const solutionMessage =
+			args.solutionId === null
+				? null
+				: await getOneFrom(
+						ctx.db,
+						"messages",
+						"by_messageId",
+						args.solutionId,
+						"id",
+					);
+
+		if (args.solutionId !== null && !solutionMessage) {
+			return { error: "SOLUTION_NOT_FOUND" as const };
+		}
+
+		if (solutionMessage && solutionMessage.serverId !== message.serverId) {
+			return { error: "SOLUTION_SERVER_MISMATCH" as const };
+		}
+
 		const existingSolutions = await ctx.db
 			.query("messages")
 			.withIndex("by_serverId_and_questionId", (q) =>
@@ -136,13 +167,13 @@ export const updateSolution = apiKeyMutation({
 			.collect();
 
 		const solutionWasAlreadySet =
-			args.solutionId !== null &&
+			solutionMessage !== null &&
 			existingSolutions.some(
-				(existingSolution) => existingSolution.id === args.solutionId,
+				(existingSolution) => existingSolution.id === solutionMessage.id,
 			);
 
 		for (const existingSolution of existingSolutions) {
-			if (existingSolution.id === args.solutionId) {
+			if (existingSolution.id === solutionMessage?.id) {
 				continue;
 			}
 			await ctx.db.patch(existingSolution._id, {
@@ -150,23 +181,8 @@ export const updateSolution = apiKeyMutation({
 			});
 		}
 
-		if (args.solutionId === null) {
-			return null;
-		}
-
-		const solutionMessage = await getOneFrom(
-			ctx.db,
-			"messages",
-			"by_messageId",
-			args.solutionId,
-			"id",
-		);
 		if (!solutionMessage) {
-			throw new Error("Solution message not found");
-		}
-
-		if (solutionMessage.serverId !== message.serverId) {
-			throw new Error("Solution message does not belong to the same server");
+			return null;
 		}
 
 		if (!solutionWasAlreadySet) {


### PR DESCRIPTION
Returns a clear not-found response when a question or solution has not been indexed yet. Existing solutions remain unchanged when a replacement message is missing.