### PR TITLE
fix: make "jump to solution" reach the solution reply

### DIFF
--- a/apps/main-site/src/components/message-page.tsx
+++ b/apps/main-site/src/components/message-page.tsx
@@ -8,7 +8,11 @@ import { HelpfulFeedback } from "@packages/ui/components/helpful-feedback";
 import { JumpToSolution } from "@packages/ui/components/jump-to-solution";
 import { Link } from "@packages/ui/components/link";
 import { MessageBody } from "@packages/ui/components/message-body";
-import { MessageResultPageProvider } from "@packages/ui/components/message-result-page-context";
+import {
+	highlightMessage,
+	MessageResultPageProvider,
+	useMessageResultPageContext,
+} from "@packages/ui/components/message-result-page-context";
 import { Separator } from "@packages/ui/components/separator";
 import { ServerIcon } from "@packages/ui/components/server-icon";
 import { ServerInviteJoinButton } from "@packages/ui/components/server-invite";
@@ -35,7 +39,7 @@ import type { FunctionReturnType } from "convex/server";
 import { CheckCircle2, MessageSquare } from "lucide-react";
 import { useQueryState } from "nuqs";
 import type { ReactNode } from "react";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { CrawlablePaginationNav } from "@/components/crawlable-pagination-nav";
 import { FloatingAskInput } from "@/components/floating-ask-input";
 import { JsonLdScript } from "@/components/json-ld-script";
@@ -172,6 +176,7 @@ export function MessageContent(props: {
 				m.message.id !== firstMessage?.message.id,
 		);
 	const convex = useConvex();
+	const { registerMessageScroller } = useMessageResultPageContext();
 	const loadMessagesPage = useCallback(
 		({ cursor, numItems }: { cursor: string | null; numItems: number }) =>
 			convex.query(api.public.messages.getMessages, {
@@ -224,6 +229,9 @@ export function MessageContent(props: {
 					initialLoaderCount={3}
 					loader={<ReplyMessageSkeleton />}
 					filterResults={filterMessages}
+					getItemId={(message) => message.message.id.toString()}
+					registerScroller={registerMessageScroller}
+					onScrolledToItem={highlightMessage}
 					emptyState={
 						<div className="text-center py-8 text-muted-foreground">
 							No replies yet
@@ -338,6 +346,8 @@ export function RepliesSection(props: {
 			}
 		: undefined;
 
+	const { registerMessageScroller } = useMessageResultPageContext();
+
 	return (
 		<>
 			<div className="rounded-md">
@@ -349,6 +359,9 @@ export function RepliesSection(props: {
 						loader={<ReplyMessageSkeleton />}
 						initialData={filteredInitialData}
 						filterResults={filterMessages}
+						getItemId={(message) => message.message.id.toString()}
+						registerScroller={registerMessageScroller}
+						onScrolledToItem={highlightMessage}
 						// biome-ignore lint/complexity/noUselessFragments: needed for now
 						emptyState={<></>}
 						footer={
@@ -399,15 +412,6 @@ export function MessagePage(props: {
 
 	const tenant = useTenant();
 	const [focusMessageId] = useQueryState("focus");
-
-	useEffect(() => {
-		if (focusMessageId) {
-			const element = document.getElementById(`message-${focusMessageId}`);
-			if (element) {
-				element.scrollIntoView({ behavior: "instant", block: "center" });
-			}
-		}
-	}, [focusMessageId]);
 
 	const rootMessageDeleted = headerData.firstMessage === null;
 	const firstMessage = headerData.firstMessage;
@@ -522,7 +526,7 @@ export function MessagePage(props: {
 			: null;
 
 	return (
-		<MessageResultPageProvider>
+		<MessageResultPageProvider focusMessageId={focusMessageId}>
 			<div className="mx-auto pt-2 pb-16">
 				{jsonLdData && (
 					<JsonLdScript data={jsonLdData} scriptKey="message-jsonld" />

--- a/packages/ui/src/components/jump-to-solution.test.tsx
+++ b/packages/ui/src/components/jump-to-solution.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { act, type ReactNode, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+import { JumpToSolution } from "./jump-to-solution";
+import {
+	MessageResultPageProvider,
+	type MessageScroller,
+	useMessageResultPageContext,
+} from "./message-result-page-context";
+
+// React needs this to run effects synchronously inside act().
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const SOLUTION_ID = "1462183916965466295";
+
+/**
+ * Stands in for the virtualized replies list: it registers a scroller the same
+ * way `SnapshotInfiniteList` does, and records what it was asked to scroll to.
+ */
+function FakeRepliesList(props: { scroller: MessageScroller }) {
+	const { registerMessageScroller } = useMessageResultPageContext();
+	const scroller = props.scroller;
+	useEffect(
+		() => registerMessageScroller(scroller),
+		[registerMessageScroller, scroller],
+	);
+	return null;
+}
+
+function render(ui: ReactNode) {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const root = createRoot(container);
+	act(() => {
+		root.render(ui);
+	});
+	return container;
+}
+
+function click(element: Element) {
+	act(() => {
+		element.dispatchEvent(
+			new MouseEvent("click", { bubbles: true, cancelable: true }),
+		);
+	});
+}
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	window.location.hash = "";
+});
+
+describe("JumpToSolution", () => {
+	it("asks the replies list to scroll to the solution", () => {
+		const scrolledTo: Array<string> = [];
+		const container = render(
+			<MessageResultPageProvider>
+				<JumpToSolution id={SOLUTION_ID} />
+				<FakeRepliesList
+					scroller={(id) => {
+						scrolledTo.push(id);
+						return true;
+					}}
+				/>
+			</MessageResultPageProvider>,
+		);
+
+		const link = container.querySelector("a");
+		expect(link?.getAttribute("href")).toBe(`#solution-${SOLUTION_ID}`);
+		click(link as Element);
+
+		expect(scrolledTo).toEqual([SOLUTION_ID]);
+	});
+
+	it("leaves the anchor alone when nothing can scroll to the solution", () => {
+		const container = render(
+			<MessageResultPageProvider>
+				<JumpToSolution id={SOLUTION_ID} />
+			</MessageResultPageProvider>,
+		);
+
+		const link = container.querySelector("a") as Element;
+		const event = new MouseEvent("click", {
+			bubbles: true,
+			cancelable: true,
+		});
+		act(() => {
+			link.dispatchEvent(event);
+		});
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+});
+
+describe("MessageResultPageProvider", () => {
+	it("resolves a #solution- deep link once the list has mounted", () => {
+		window.location.hash = `#solution-${SOLUTION_ID}`;
+		const scrolledTo: Array<string> = [];
+
+		render(
+			<MessageResultPageProvider>
+				<FakeRepliesList
+					scroller={(id) => {
+						scrolledTo.push(id);
+						return true;
+					}}
+				/>
+			</MessageResultPageProvider>,
+		);
+
+		expect(scrolledTo).toEqual([SOLUTION_ID]);
+	});
+
+	it("ignores hashes that do not point at a message", () => {
+		window.location.hash = "#pricing";
+		const scrolledTo: Array<string> = [];
+
+		render(
+			<MessageResultPageProvider>
+				<FakeRepliesList
+					scroller={(id) => {
+						scrolledTo.push(id);
+						return true;
+					}}
+				/>
+			</MessageResultPageProvider>,
+		);
+
+		expect(scrolledTo).toEqual([]);
+	});
+});

--- a/packages/ui/src/components/jump-to-solution.tsx
+++ b/packages/ui/src/components/jump-to-solution.tsx
@@ -4,12 +4,16 @@ import { Link } from "./link";
 import { useMessageResultPageContext } from "./message-result-page-context";
 
 export function JumpToSolution(props: { id: string }) {
-	const { setShowAllMessages } = useMessageResultPageContext();
+	const { scrollToMessage } = useMessageResultPageContext();
 	return (
 		<Link
 			href={`#solution-${props.id}`}
-			onClick={() => {
-				setShowAllMessages(true);
+			onClick={(event) => {
+				// The solution reply lives in a virtualized list, so the browser
+				// cannot resolve the anchor until the list has rendered it.
+				if (scrollToMessage(props.id)) {
+					event.preventDefault();
+				}
 			}}
 			className="text-blue-600 hover:underline dark:text-blue-400"
 		>

--- a/packages/ui/src/components/message-result-page-context.tsx
+++ b/packages/ui/src/components/message-result-page-context.tsx
@@ -1,46 +1,108 @@
 "use client";
 
-import { createContext, useCallback, useContext, useState } from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+} from "react";
+import { messageElementIds, messageIdFromHash } from "../utils/scroll-target";
+
+const HIGHLIGHT_CLASS = "bg-accent/50";
+const HIGHLIGHT_MS = 2000;
+
+/**
+ * Scrolls to a message that lives inside a virtualized list, where the element
+ * is not in the DOM until the list has loaded and rendered it. Returns false
+ * when the list cannot reach the message.
+ */
+export type MessageScroller = (messageId: string) => boolean;
+
+export function findMessageElement(messageId: string): HTMLElement | null {
+	for (const id of messageElementIds(messageId)) {
+		const element = document.getElementById(id);
+		if (element) {
+			return element;
+		}
+	}
+	return null;
+}
+
+export function highlightMessage(messageId: string): boolean {
+	const element = findMessageElement(messageId);
+	if (!element) {
+		return false;
+	}
+	element.classList.add(HIGHLIGHT_CLASS);
+	setTimeout(() => {
+		element.classList.remove(HIGHLIGHT_CLASS);
+	}, HIGHLIGHT_MS);
+	return true;
+}
 
 const MessageResultPageContext = createContext<{
-	showAllMessages: boolean;
-	setShowAllMessages: (showAllMessages: boolean) => void;
 	scrollToMessage: (messageId: string) => boolean;
+	registerMessageScroller: (scroller: MessageScroller) => () => void;
 	currentPageUrl: string | null;
 }>({
-	showAllMessages: false,
-	setShowAllMessages: () => {},
 	scrollToMessage: () => false,
+	registerMessageScroller: () => () => {},
 	currentPageUrl: null,
 });
 
 export const MessageResultPageProvider = (props: {
 	children: React.ReactNode;
 	currentPageUrl?: string;
+	/** Message to scroll to on load, e.g. from the `?focus=` search param. */
+	focusMessageId?: string | null;
 }) => {
-	const [showAllMessages, setShowAllMessages] = useState(false);
+	const scrollerRef = useRef<MessageScroller | null>(null);
+	const pendingMessageIdRef = useRef<string | null>(null);
 
 	const scrollToMessage = useCallback((messageId: string) => {
-		const element =
-			document.getElementById(`message-${messageId}`) ??
-			document.getElementById(`solution-${messageId}`);
+		const element = findMessageElement(messageId);
 		if (element) {
 			element.scrollIntoView({ behavior: "smooth", block: "center" });
-			element.classList.add("bg-accent/50");
-			setTimeout(() => {
-				element.classList.remove("bg-accent/50");
-			}, 2000);
+			highlightMessage(messageId);
 			return true;
 		}
+		const scroller = scrollerRef.current;
+		if (scroller) {
+			return scroller(messageId);
+		}
+		// The replies list has not mounted yet, retry once it registers itself.
+		pendingMessageIdRef.current = messageId;
 		return false;
 	}, []);
+
+	const registerMessageScroller = useCallback((scroller: MessageScroller) => {
+		scrollerRef.current = scroller;
+		const pending = pendingMessageIdRef.current;
+		if (pending !== null) {
+			pendingMessageIdRef.current = null;
+			scroller(pending);
+		}
+		return () => {
+			if (scrollerRef.current === scroller) {
+				scrollerRef.current = null;
+			}
+		};
+	}, []);
+
+	const focusMessageId = props.focusMessageId ?? null;
+	useEffect(() => {
+		const target = focusMessageId ?? messageIdFromHash(window.location.hash);
+		if (target) {
+			scrollToMessage(target);
+		}
+	}, [focusMessageId, scrollToMessage]);
 
 	return (
 		<MessageResultPageContext.Provider
 			value={{
-				showAllMessages,
-				setShowAllMessages,
 				scrollToMessage,
+				registerMessageScroller,
 				currentPageUrl: props.currentPageUrl ?? null,
 			}}
 		>

--- a/packages/ui/src/components/snapshot-infinite-list.tsx
+++ b/packages/ui/src/components/snapshot-infinite-list.tsx
@@ -9,7 +9,8 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { Virtuoso } from "react-virtuoso";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
+import { resolveScrollTarget } from "../utils/scroll-target";
 
 type SnapshotPage<Item> = {
 	page: Array<Item>;
@@ -33,7 +34,21 @@ type SnapshotInfiniteListProps<Item> = {
 	itemClassName?: string;
 	initialData?: SnapshotPage<Item>;
 	filterResults?: (items: Array<Item>) => Array<Item>;
+	/** Stable id per item, required for `registerScroller` to find an item. */
+	getItemId?: (item: Item) => string;
+	/**
+	 * Hands the caller a function that scrolls an item into view by id, loading
+	 * further pages until the item is found. Returns a cleanup function.
+	 */
+	registerScroller?: (scroller: (itemId: string) => boolean) => () => void;
+	/**
+	 * Called once the scrolled-to item has rendered. Return false to be called
+	 * again on the next frame, e.g. while waiting for the element to mount.
+	 */
+	onScrolledToItem?: (itemId: string) => boolean;
 };
+
+const SCROLL_RENDER_ATTEMPTS = 30;
 
 function LoadingSkeletons({
 	count,
@@ -64,8 +79,13 @@ export function SnapshotInfiniteList<Item>({
 	itemClassName = "mb-4",
 	initialData,
 	filterResults,
+	getItemId,
+	registerScroller,
+	onScrolledToItem,
 }: SnapshotInfiniteListProps<Item>) {
 	const generationRef = useRef(0);
+	const virtuosoRef = useRef<VirtuosoHandle>(null);
+	const pendingScrollIdRef = useRef<string | null>(null);
 	const lastLoadedLength = useRef(0);
 	const [pages, setPages] = useState<Array<SnapshotPage<Item>>>(() =>
 		initialData ? [initialData] : [],
@@ -188,6 +208,93 @@ export function SnapshotInfiniteList<Item>({
 		[canLoadMore, continueCursor, fetchPage, pageSize, results],
 	);
 
+	const loadNextPage = useEffectEvent(() => {
+		if (!canLoadMore || continueCursor === null) {
+			return;
+		}
+		setIsLoadingMore(true);
+		void fetchPage({
+			cursor: continueCursor,
+			numItems: pageSize,
+			append: true,
+			generation: generationRef.current,
+		});
+	});
+
+	const scrollToItemIndex = useEffectEvent((index: number, itemId: string) => {
+		virtuosoRef.current?.scrollToIndex({
+			index,
+			align: "center",
+			behavior: "auto",
+		});
+		if (!onScrolledToItem) {
+			return;
+		}
+		// The item mounts a frame or two after Virtuoso scrolls to it.
+		let attempts = SCROLL_RENDER_ATTEMPTS;
+		const tick = () => {
+			if (onScrolledToItem(itemId) || attempts-- <= 0) {
+				return;
+			}
+			requestAnimationFrame(tick);
+		};
+		requestAnimationFrame(tick);
+	});
+
+	const scrollToItem = useEffectEvent((itemId: string) => {
+		if (!getItemId) {
+			return false;
+		}
+		const resolution = resolveScrollTarget({
+			items: results,
+			getItemId,
+			targetId: itemId,
+			isDone,
+		});
+		if (resolution.type === "scroll") {
+			pendingScrollIdRef.current = null;
+			scrollToItemIndex(resolution.index, itemId);
+			return true;
+		}
+		if (resolution.type === "unreachable") {
+			return false;
+		}
+		// Not paged in yet, keep loading until it shows up.
+		pendingScrollIdRef.current = itemId;
+		loadNextPage();
+		return true;
+	});
+
+	useEffect(() => {
+		if (!registerScroller) {
+			return;
+		}
+		return registerScroller(scrollToItem);
+	}, [registerScroller]);
+
+	useEffect(() => {
+		const pending = pendingScrollIdRef.current;
+		if (pending === null || !getItemId) {
+			return;
+		}
+		const resolution = resolveScrollTarget({
+			items: results,
+			getItemId,
+			targetId: pending,
+			isDone,
+		});
+		if (resolution.type === "scroll") {
+			pendingScrollIdRef.current = null;
+			scrollToItemIndex(resolution.index, pending);
+			return;
+		}
+		if (resolution.type === "unreachable") {
+			pendingScrollIdRef.current = null;
+			return;
+		}
+		loadNextPage();
+	}, [results, isDone, getItemId]);
+
 	if (error) {
 		throw error;
 	}
@@ -219,6 +326,7 @@ export function SnapshotInfiniteList<Item>({
 
 	return (
 		<Virtuoso
+			ref={virtuosoRef}
 			useWindowScroll
 			data={results}
 			className={className}

--- a/packages/ui/src/utils/scroll-target.test.ts
+++ b/packages/ui/src/utils/scroll-target.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+	messageElementIds,
+	messageIdFromHash,
+	resolveScrollTarget,
+} from "./scroll-target";
+
+describe("messageIdFromHash", () => {
+	it("reads the id out of a solution hash", () => {
+		expect(messageIdFromHash("#solution-1462183916965466295")).toBe(
+			"1462183916965466295",
+		);
+	});
+
+	it("reads the id out of a message hash", () => {
+		expect(messageIdFromHash("#message-1462183916965466295")).toBe(
+			"1462183916965466295",
+		);
+	});
+
+	it("accepts a hash without the leading #", () => {
+		expect(messageIdFromHash("solution-123")).toBe("123");
+	});
+
+	it("ignores hashes that do not point at a message", () => {
+		expect(messageIdFromHash("#pricing")).toBeNull();
+		expect(messageIdFromHash("#solution")).toBeNull();
+		expect(messageIdFromHash("")).toBeNull();
+		expect(messageIdFromHash(null)).toBeNull();
+	});
+
+	it("ignores non numeric ids", () => {
+		expect(messageIdFromHash("#solution-<script>")).toBeNull();
+		expect(messageIdFromHash("#message-abc")).toBeNull();
+	});
+});
+
+describe("resolveScrollTarget", () => {
+	const getItemId = (item: { id: string }) => item.id;
+	const loaded = [{ id: "1" }, { id: "2" }, { id: "3" }];
+
+	it("scrolls to an item that is already loaded", () => {
+		expect(
+			resolveScrollTarget({
+				items: loaded,
+				getItemId,
+				targetId: "3",
+				isDone: false,
+			}),
+		).toEqual({ type: "scroll", index: 2 });
+	});
+
+	it("loads more pages when the item has not been paged in", () => {
+		expect(
+			resolveScrollTarget({
+				items: loaded,
+				getItemId,
+				targetId: "9",
+				isDone: false,
+			}),
+		).toEqual({ type: "loadMore" });
+	});
+
+	it("loads more pages when nothing is loaded yet", () => {
+		expect(
+			resolveScrollTarget({
+				items: [],
+				getItemId,
+				targetId: "9",
+				isDone: false,
+			}),
+		).toEqual({ type: "loadMore" });
+	});
+
+	it("gives up only once every page is loaded", () => {
+		expect(
+			resolveScrollTarget({
+				items: loaded,
+				getItemId,
+				targetId: "9",
+				isDone: true,
+			}),
+		).toEqual({ type: "unreachable" });
+	});
+});
+
+describe("messageElementIds", () => {
+	it("covers both the reply and the solution rendering of a message", () => {
+		expect(messageElementIds("123")).toEqual(["message-123", "solution-123"]);
+	});
+});

--- a/packages/ui/src/utils/scroll-target.ts
+++ b/packages/ui/src/utils/scroll-target.ts
@@ -1,0 +1,64 @@
+const MESSAGE_ELEMENT_PREFIX = "message-";
+const SOLUTION_ELEMENT_PREFIX = "solution-";
+
+const SNOWFLAKE_PATTERN = /^\d{1,25}$/;
+
+/**
+ * Element ids a message can be rendered under. A reply that is the accepted
+ * solution renders as `solution-<id>`, every other reply as `message-<id>`.
+ */
+export function messageElementIds(messageId: string): Array<string> {
+	return [
+		`${MESSAGE_ELEMENT_PREFIX}${messageId}`,
+		`${SOLUTION_ELEMENT_PREFIX}${messageId}`,
+	];
+}
+
+/**
+ * Reads the message id out of a `#message-<id>` / `#solution-<id>` hash.
+ * Returns null for hashes that do not point at a message.
+ */
+export function messageIdFromHash(
+	hash: string | null | undefined,
+): string | null {
+	if (!hash) {
+		return null;
+	}
+	const withoutHash = hash.startsWith("#") ? hash.slice(1) : hash;
+	const prefix = [MESSAGE_ELEMENT_PREFIX, SOLUTION_ELEMENT_PREFIX].find(
+		(candidate) => withoutHash.startsWith(candidate),
+	);
+	if (!prefix) {
+		return null;
+	}
+	const id = withoutHash.slice(prefix.length);
+	return SNOWFLAKE_PATTERN.test(id) ? id : null;
+}
+
+export type ScrollResolution =
+	/** The item is loaded and can be scrolled to. */
+	| { type: "scroll"; index: number }
+	/** The item has not been paged in yet. */
+	| { type: "loadMore" }
+	/** Every page is loaded and the item is not among them. */
+	| { type: "unreachable" };
+
+/**
+ * Decides what a paginated list should do when asked to scroll to an item.
+ * A list that only looks at what it has already loaded silently does nothing
+ * for items further down, which is why targets have to page in first.
+ */
+export function resolveScrollTarget<Item>(args: {
+	items: ReadonlyArray<Item>;
+	getItemId: (item: Item) => string;
+	targetId: string;
+	isDone: boolean;
+}): ScrollResolution {
+	const index = args.items.findIndex(
+		(item) => args.getItemId(item) === args.targetId,
+	);
+	if (index >= 0) {
+		return { type: "scroll", index };
+	}
+	return args.isDone ? { type: "unreachable" } : { type: "loadMore" };
+}


### PR DESCRIPTION
Fixes #892

### The bug

Clicking "Jump to solution" does nothing, and opening a page with a `#solution-<id>` hash does nothing either.

Replies are rendered by `SnapshotInfiniteList`, which is a `react-virtuoso` window list on top of cursor pagination. Two things follow from that:

- the solution reply is usually not in the loaded page set yet, and
- even after it loads, only the items near the viewport are mounted.

So `#solution-<id>` points at an element that is not in the DOM, and the browser's native anchor scroll has nothing to scroll to.

The same applies to the two existing code paths that tried to handle this:

- `JumpToSolution` only called `setShowAllMessages(true)`, and nothing in the app ever read `showAllMessages` - it was dead state - so the click relied entirely on the native anchor.
- the `?focus=` effect in `message-page.tsx` did a single `getElementById` on mount, before the replies had loaded, and silently gave up when it returned null.
- `ReplyBar`'s `scrollToMessage` had the same one-shot `getElementById` behaviour and fell back to a full page navigation.

### The fix

Teach the list to reach an item that is not loaded or not mounted yet, and route every "scroll to this message" caller through it.

- `SnapshotInfiniteList` takes an optional `getItemId` and `registerScroller`. The scroller looks the item up in what is loaded; if it is not there it keeps requesting the next page and retries as pages arrive, then calls `Virtuoso.scrollToIndex` so the item actually mounts. `onScrolledToItem` is retried for a few frames because the row mounts after the scroll.
- `MessageResultPageProvider` owns `scrollToMessage`: it tries the DOM first (the solution card at the top of the page is not virtualized), then hands off to the list. If the click happens before the list has mounted, the target is held and flushed when the list registers, which is what makes a `#solution-<id>` deep link work on load.
- `JumpToSolution` calls `scrollToMessage` and only prevents the default anchor when the scroll was handled, so nothing regresses where there is no list.
- `?focus=` handling moved into the provider, so it goes through the same path instead of its own one-shot lookup.
- Removed `showAllMessages` / `setShowAllMessages` from the context - nothing read them.

The paging-vs-give-up decision is `resolveScrollTarget` in `packages/ui/src/utils/scroll-target.ts`, kept pure so it can be tested directly. `messageIdFromHash` parses the deep link and ignores anything that is not a snowflake.

### Tests

- `packages/ui/src/utils/scroll-target.test.ts` covers the hash parsing and the resolver, including the case this bug was: target not loaded and pagination not finished has to load more rather than resolve to nothing.
- `packages/ui/src/components/jump-to-solution.test.tsx` renders the provider with a stand-in list and asserts that a click, and a `#solution-<id>` on load, actually reach the list.

On this branch:

```
✓ src/utils/scroll-target.test.ts (10 tests)
✓ src/components/jump-to-solution.test.tsx (4 tests)

Test Files  2 passed (2)
     Tests  14 passed (14)
```

With the component tests kept and the fix reverted, the behaviour they describe is gone:

```
× JumpToSolution > asks the replies list to scroll to the solution
✓ JumpToSolution > leaves the anchor alone when nothing can scroll to the solution
× MessageResultPageProvider > resolves a #solution- deep link once the list has mounted
× MessageResultPageProvider > ignores hashes that do not point at a message

Tests  3 failed | 1 passed (4)
```

`bun run lint` and `tsgo --noEmit` on `@packages/ui` and `@apps/main-site` are clean.

### Known limit

The replies list also has crawlable cursor pagination. If the solution is on an earlier cursor page than the one being viewed, the list cannot page backwards to it, so `scrollToMessage` returns false and the plain anchor navigation happens as before. The common case (`/m/<id>` with no cursor) walks forward from the start and reaches it.
