### PR TITLE
Fix Discord sign-in 502 by stripping hop-by-hop auth proxy headers

### DIFF
--- a/apps/main-site/src/app/(main-site)/api/handlers/auth.test.ts
+++ b/apps/main-site/src/app/(main-site)/api/handlers/auth.test.ts
@@ -68,6 +68,7 @@ describe("handleAuth proxyToConvex", () => {
 	it("strips transfer-encoding and content-length from chunked POSTs", async () => {
 		handlerPOST.mockImplementation(async (req: Request) => {
 			expect(req.headers.get("transfer-encoding")).toBeNull();
+			expect(req.headers.get("te")).toBeNull();
 			expect(req.headers.get("content-length")).toBeNull();
 			expect(req.headers.get("connection")).toBeNull();
 			expect(req.headers.get("content-type")).toBe("application/json");
@@ -88,6 +89,7 @@ describe("handleAuth proxyToConvex", () => {
 		// them on so the strip path is actually exercised.
 		const headers = new Headers(request.headers);
 		headers.set("transfer-encoding", "chunked");
+		headers.set("te", "trailers");
 		headers.set("content-length", "9999");
 		headers.set("connection", "keep-alive");
 		Object.defineProperty(request, "headers", { value: headers });

--- a/apps/main-site/src/app/(main-site)/api/handlers/auth.test.ts
+++ b/apps/main-site/src/app/(main-site)/api/handlers/auth.test.ts
@@ -65,6 +65,40 @@ describe("handleAuth proxyToConvex", () => {
 		expect(handlerPOST).toHaveBeenCalledTimes(1);
 	});
 
+	it("strips transfer-encoding and content-length from chunked POSTs", async () => {
+		handlerPOST.mockImplementation(async (req: Request) => {
+			expect(req.headers.get("transfer-encoding")).toBeNull();
+			expect(req.headers.get("content-length")).toBeNull();
+			expect(req.headers.get("connection")).toBeNull();
+			expect(req.headers.get("content-type")).toBe("application/json");
+			expect(await req.text()).toBe('{"provider":"discord"}');
+			return new Response(JSON.stringify({ ok: true }), { status: 200 });
+		});
+
+		const request = new Request(
+			"https://www.answeroverflow.com/api/auth/sign-in/social",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: '{"provider":"discord"}',
+			},
+		);
+		// The Request constructor may refuse to carry framing headers alongside a
+		// body, but real incoming Vercel requests expose them via .headers; force
+		// them on so the strip path is actually exercised.
+		const headers = new Headers(request.headers);
+		headers.set("transfer-encoding", "chunked");
+		headers.set("content-length", "9999");
+		headers.set("connection", "keep-alive");
+		Object.defineProperty(request, "headers", { value: headers });
+		expect(request.headers.get("transfer-encoding")).toBe("chunked");
+		expect(request.headers.get("content-length")).toBe("9999");
+
+		const response = await handleAuth(makeContext(request));
+		expect(response.status).toBe(200);
+		expect(handlerPOST).toHaveBeenCalledTimes(1);
+	});
+
 	it("retries once after TypeError fetch failed and succeeds with replayable body", async () => {
 		const fetchFailed = new TypeError("fetch failed");
 		(fetchFailed as Error & { cause?: unknown }).cause = {

--- a/apps/main-site/src/app/(main-site)/api/handlers/auth.ts
+++ b/apps/main-site/src/app/(main-site)/api/handlers/auth.ts
@@ -69,6 +69,7 @@ export async function proxyToConvex(request: Request): Promise<Response> {
 		// buffered request, so drop them and let fetch set Content-Length.
 		const headers = new Headers(request.headers);
 		headers.delete("transfer-encoding");
+		headers.delete("te");
 		headers.delete("content-length");
 		headers.delete("connection");
 		headers.delete("keep-alive");

--- a/apps/main-site/src/app/(main-site)/api/handlers/auth.ts
+++ b/apps/main-site/src/app/(main-site)/api/handlers/auth.ts
@@ -63,13 +63,22 @@ export async function proxyToConvex(request: Request): Promise<Response> {
 		request.method === "GET" || request.method === "HEAD"
 			? undefined
 			: await request.arrayBuffer();
-	const makeRequest = () =>
-		new Request(url, {
+	const makeRequest = () => {
+		// Hop-by-hop / body-framing headers describe the incoming stream, not the
+		// buffered body we forward; undici rejects chunked transfer-encoding on a
+		// buffered request, so drop them and let fetch set Content-Length.
+		const headers = new Headers(request.headers);
+		headers.delete("transfer-encoding");
+		headers.delete("content-length");
+		headers.delete("connection");
+		headers.delete("keep-alive");
+		return new Request(url, {
 			method: request.method,
-			headers: request.headers,
+			headers,
 			// Copy so undici/fetch cannot detach the buffer across retries
 			body: bodyBuffer ? bodyBuffer.slice(0) : undefined,
 		});
+	};
 	const proxy = request.method === "GET" ? handler.GET : handler.POST;
 	try {
 		return await proxy(makeRequest());


### PR DESCRIPTION
## Summary
- Incoming POSTs still carry `Transfer-Encoding: chunked` after PR 925 buffers the auth body. Copying those headers onto a new Request with a buffered body makes Undici throw `invalid transfer-encoding header` (`UND_ERR_INVALID_ARG`) before Convex is reached, so both the first attempt and the retry 502.
- Clone headers in `proxyToConvex` `makeRequest` and drop hop-by-hop / body-framing headers (`transfer-encoding`, `content-length`, `connection`, `keep-alive`) so fetch can set `Content-Length` from the buffered body.
- Add a test that an incoming chunked POST is forwarded without those framing headers, body still readable, `handlerPOST` called once, 200.

## Test plan
- [x] `cd apps/main-site && bunx vitest run --no-watch --pool=forks` — 6/6 passed
- [ ] CI lint + typecheck green
- [ ] Confirm Discord sign-in on prod after deploy (POST `/api/auth/sign-in/social` no longer origin-502s)