### PR TITLE
Fix inline Discord code rendering twice

### DIFF
--- a/packages/ui/src/components/code.test.tsx
+++ b/packages/ui/src/components/code.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { cn } from "../lib/utils";
+import { InlineCode } from "./code";
+
+describe("cn", () => {
+	it("keeps theme visibility classes when they come after a display class", () => {
+		expect(cn("inline-block", "dark:hidden")).toContain("dark:hidden");
+		expect(cn("inline-block", "hidden dark:inline").split(" ")).toContain(
+			"hidden",
+		);
+	});
+});
+
+describe("InlineCode", () => {
+	const renderThemeSpans = (code: string, language?: string) => {
+		const container = document.createElement("div");
+		container.innerHTML = renderToStaticMarkup(
+			<InlineCode code={code} language={language} />,
+		);
+		const wrapper = container.firstElementChild;
+		if (!wrapper) throw new Error("InlineCode rendered no wrapper");
+		return [...wrapper.children];
+	};
+
+	it("shows exactly one theme copy per mode", () => {
+		for (const language of [undefined, "typescript"]) {
+			const [light, dark] = renderThemeSpans("HashMap", language);
+			expect(light?.classList.contains("dark:hidden")).toBe(true);
+			expect(light?.classList.contains("hidden")).toBe(false);
+			expect(dark?.classList.contains("hidden")).toBe(true);
+			expect(dark?.classList.contains("dark:inline")).toBe(true);
+			expect(light?.textContent).toBe("HashMap");
+			expect(dark?.textContent).toBe("HashMap");
+		}
+	});
+});

--- a/packages/ui/src/components/code.tsx
+++ b/packages/ui/src/components/code.tsx
@@ -103,11 +103,11 @@ function InlineCodeInternal({
 	return (
 		<>
 			<span
-				className={cn("dark:hidden", className)}
+				className={cn(className, "dark:hidden")}
 				dangerouslySetInnerHTML={{ __html: lightHtml }}
 			/>
 			<span
-				className={cn("hidden dark:inline", className)}
+				className={cn(className, "hidden dark:inline")}
 				dangerouslySetInnerHTML={{ __html: darkHtml }}
 			/>
 		</>
@@ -142,11 +142,7 @@ export function InlineCode({
 }) {
 	return (
 		<span className="relative inline-block max-w-full">
-			<InlineCodeInternal
-				code={code}
-				language={language}
-				className="inline-block"
-			/>
+			<InlineCodeInternal code={code} language={language} />
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary
- Inline `` `code` `` was rendering twice (e.g. HashMapHashMap) because `InlineCode` passed `inline-block` into `cn()`/`twMerge`, which dropped `hidden` from the dark-theme span so both light and dark copies were visible.
- Visibility classes now win the merge, and the extra `inline-block` on the inner spans is gone.
- Adds a focused `packages/ui` vitest covering the class merge and one-copy-per-theme render.

## Test plan
- [x] `bun run test` in `packages/ui` (2 tests pass)
- [ ] CI lint + typecheck
- [ ] After deploy, confirm https://www.answeroverflow.com/m/1523372894955241678 shows HashMap / put / get once