### PR TITLE
Rehost forwarded Discord images onto the CDN

### DIFF
--- a/apps/discord-bot/src/services/indexing.ts
+++ b/apps/discord-bot/src/services/indexing.ts
@@ -49,6 +49,7 @@ import {
 	catchAllCauseWithReport,
 	catchAllWithReport,
 } from "../utils/error-reporting";
+import { extractSnapshotMediaToUpload } from "../utils/snapshot-media";
 
 const INDEXING_CONFIG = {
 	cronExpression: "0 */6 * * *",
@@ -595,14 +596,15 @@ function upsertMessages(
 
 function uploadMedia(messages: Message[], channelId: string) {
 	return Effect.gen(function* () {
-		const allAttachments = Arr.flatMap(messages, (msg) =>
-			Arr.map(Arr.fromIterable(msg.attachments.values()), (att) => ({
+		const allAttachments = Arr.flatMap(messages, (msg) => [
+			...Arr.map(Arr.fromIterable(msg.attachments.values()), (att) => ({
 				id: att.id,
 				url: att.url,
 				filename: att.name ?? "",
 				contentType: att.contentType ?? undefined,
 			})),
-		);
+			...extractSnapshotMediaToUpload(msg),
+		]);
 
 		if (allAttachments.length > 0) {
 			yield* uploadAttachmentsInBatches(allAttachments);

--- a/apps/discord-bot/src/sync/message.ts
+++ b/apps/discord-bot/src/sync/message.ts
@@ -19,6 +19,7 @@ import {
 	toUpsertMessageArgs,
 } from "../utils/conversions";
 import { catchAllWithReport } from "../utils/error-reporting";
+import { extractSnapshotMediaToUpload } from "../utils/snapshot-media";
 
 const BATCH_CONFIG = {
 	maxBatchSize: process.env.NODE_ENV === "production" ? 3 : 1,
@@ -132,16 +133,17 @@ export const MessageParityLayer = Layer.scopedDiscard(
 					toAOMessage(newMessage, server.discordId.toString()),
 				);
 
-				if (newMessage.attachments.size > 0) {
-					const attachmentsToUpload = Array.from(
-						newMessage.attachments.values(),
-					).map((att) => ({
+				const attachmentsToUpload = [
+					...Array.from(newMessage.attachments.values()).map((att) => ({
 						id: att.id,
 						url: att.url,
 						filename: att.name ?? "",
 						contentType: att.contentType ?? undefined,
-					}));
+					})),
+					...extractSnapshotMediaToUpload(newMessage),
+				];
 
+				if (attachmentsToUpload.length > 0) {
 					yield* uploadAttachmentsInBatches(attachmentsToUpload).pipe(
 						Effect.withSpan("sync.message.upload_attachments", {
 							attributes: {
@@ -308,16 +310,17 @@ export const MessageParityLayer = Layer.scopedDiscard(
 					toChannelKeyedArgs(toUpsertMessageArgs(data)),
 				);
 
-				if (message.attachments.size > 0) {
-					const attachmentsToUpload = Array.from(
-						message.attachments.values(),
-					).map((att) => ({
+				const attachmentsToUpload = [
+					...Array.from(message.attachments.values()).map((att) => ({
 						id: att.id,
 						url: att.url,
 						filename: att.name ?? "",
 						contentType: att.contentType ?? undefined,
-					}));
+					})),
+					...extractSnapshotMediaToUpload(message),
+				];
 
+				if (attachmentsToUpload.length > 0) {
 					yield* uploadAttachmentsInBatches(attachmentsToUpload).pipe(
 						Effect.withSpan("sync.message.upload_attachments", {
 							attributes: {

--- a/apps/discord-bot/src/utils/snapshot-media.test.ts
+++ b/apps/discord-bot/src/utils/snapshot-media.test.ts
@@ -1,0 +1,102 @@
+import { type Message, MessageReferenceType } from "discord.js";
+import { describe, expect, it } from "vitest";
+import { extractSnapshotMediaToUpload } from "./snapshot-media";
+
+function mockForwardMessage(snapshot: unknown): Message {
+	return {
+		reference: { type: MessageReferenceType.Forward },
+		messageSnapshots: { first: () => snapshot },
+	} as unknown as Message;
+}
+
+describe("extractSnapshotMediaToUpload", () => {
+	it("collects attachments from a forwarded message snapshot", () => {
+		const message = mockForwardMessage({
+			attachments: new Map([
+				[
+					"222",
+					{
+						id: "222",
+						url: "https://cdn.discordapp.com/attachments/111/222/image.png?ex=68b0&is=68af&hm=abc",
+						name: "image.png",
+						contentType: "image/png",
+					},
+				],
+			]),
+			embeds: [],
+		});
+
+		expect(extractSnapshotMediaToUpload(message)).toEqual([
+			{
+				id: "222",
+				url: "https://cdn.discordapp.com/attachments/111/222/image.png?ex=68b0&is=68af&hm=abc",
+				filename: "image.png",
+				contentType: "image/png",
+			},
+		]);
+	});
+
+	it("collects snapshot embed images hosted on the discord cdn", () => {
+		const message = mockForwardMessage({
+			attachments: new Map(),
+			embeds: [
+				{
+					image: {
+						url: "https://media.discordapp.net/attachments/111/333/embed.png?ex=68b0",
+					},
+					thumbnail: {
+						url: "https://example.com/external.png",
+					},
+				},
+			],
+		});
+
+		expect(extractSnapshotMediaToUpload(message)).toEqual([
+			{
+				id: "333",
+				url: "https://media.discordapp.net/attachments/111/333/embed.png?ex=68b0",
+				filename: "embed.png",
+			},
+		]);
+	});
+
+	it("dedupes embed images that duplicate a snapshot attachment", () => {
+		const url =
+			"https://cdn.discordapp.com/attachments/111/222/image.png?ex=68b0";
+		const message = mockForwardMessage({
+			attachments: new Map([
+				[
+					"222",
+					{ id: "222", url, name: "image.png", contentType: "image/png" },
+				],
+			]),
+			embeds: [{ image: { url } }],
+		});
+
+		expect(extractSnapshotMediaToUpload(message)).toHaveLength(1);
+	});
+
+	it("returns nothing for a normal message", () => {
+		const message = {
+			reference: null,
+			messageSnapshots: { first: () => undefined },
+		} as unknown as Message;
+
+		expect(extractSnapshotMediaToUpload(message)).toEqual([]);
+	});
+
+	it("returns nothing for a reply reference", () => {
+		const message = {
+			reference: { type: MessageReferenceType.Default },
+			messageSnapshots: { first: () => undefined },
+		} as unknown as Message;
+
+		expect(extractSnapshotMediaToUpload(message)).toEqual([]);
+	});
+
+	it("returns nothing for a forward without a snapshot", () => {
+		expect(extractSnapshotMediaToUpload(mockForwardMessage(undefined))).toEqual(
+			[],
+		);
+	});
+});

--- a/apps/discord-bot/src/utils/snapshot-media.ts
+++ b/apps/discord-bot/src/utils/snapshot-media.ts
@@ -1,0 +1,68 @@
+import { parseDiscordAttachmentUrl } from "@packages/database/convex/shared/mediaUrl";
+import { type Message, MessageReferenceType } from "discord.js";
+
+export interface SnapshotMediaToUpload {
+	id: string;
+	url: string;
+	filename: string;
+	contentType?: string;
+}
+
+/**
+ * Collects media from a forwarded message's snapshot so the bytes can be
+ * rehosted on S3 under `${attachmentId}/${filename}` before the signed
+ * Discord CDN URLs expire. Snapshot attachments are not stored in the
+ * regular attachments table, so they are never picked up by the normal
+ * attachment upload path.
+ */
+export function extractSnapshotMediaToUpload(
+	message: Message,
+): SnapshotMediaToUpload[] {
+	if (message.reference?.type !== MessageReferenceType.Forward) {
+		return [];
+	}
+
+	const snapshot = message.messageSnapshots?.first();
+	if (!snapshot) {
+		return [];
+	}
+
+	const result: SnapshotMediaToUpload[] = [];
+	const seen = new Set<string>();
+	const add = (item: SnapshotMediaToUpload) => {
+		const key = `${item.id}/${item.filename}`;
+		if (seen.has(key)) {
+			return;
+		}
+		seen.add(key);
+		result.push(item);
+	};
+
+	for (const attachment of snapshot.attachments?.values() ?? []) {
+		add({
+			id: attachment.id,
+			url: attachment.url,
+			filename: attachment.name ?? "",
+			contentType: attachment.contentType ?? undefined,
+		});
+	}
+
+	for (const embed of snapshot.embeds ?? []) {
+		for (const url of [
+			embed.image?.url,
+			embed.thumbnail?.url,
+			embed.video?.url,
+		]) {
+			if (!url) {
+				continue;
+			}
+			const parsed = parseDiscordAttachmentUrl(url);
+			if (!parsed) {
+				continue;
+			}
+			add({ id: parsed.id, url, filename: parsed.filename });
+		}
+	}
+
+	return result;
+}

--- a/packages/database/convex/shared/mediaUrl.test.ts
+++ b/packages/database/convex/shared/mediaUrl.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+import {
+	cdnUrlForAttachment,
+	parseDiscordAttachmentUrl,
+	rewriteDiscordMediaUrlToCdn,
+} from "./mediaUrl";
+
+const CDN_DOMAIN = "cdn.answeroverflow.com";
+
+describe("cdnUrlForAttachment", () => {
+	test("builds a cdn url from id and filename", () => {
+		expect(cdnUrlForAttachment(123n, "image.png", CDN_DOMAIN)).toBe(
+			"https://cdn.answeroverflow.com/123/image.png",
+		);
+	});
+
+	test("accepts string ids", () => {
+		expect(cdnUrlForAttachment("456", "file.gif", CDN_DOMAIN)).toBe(
+			"https://cdn.answeroverflow.com/456/file.gif",
+		);
+	});
+});
+
+describe("parseDiscordAttachmentUrl", () => {
+	test("parses a signed cdn.discordapp.com attachment url", () => {
+		expect(
+			parseDiscordAttachmentUrl(
+				"https://cdn.discordapp.com/attachments/111/222/image.png?ex=68b0&is=68af&hm=abc",
+			),
+		).toEqual({ id: "222", filename: "image.png" });
+	});
+
+	test("parses a media.discordapp.net attachment url", () => {
+		expect(
+			parseDiscordAttachmentUrl(
+				"https://media.discordapp.net/attachments/111/222/image.png",
+			),
+		).toEqual({ id: "222", filename: "image.png" });
+	});
+
+	test("decodes percent-encoded filenames", () => {
+		expect(
+			parseDiscordAttachmentUrl(
+				"https://cdn.discordapp.com/attachments/111/222/my%20image.png",
+			),
+		).toEqual({ id: "222", filename: "my image.png" });
+	});
+
+	test("returns null for non-discord hosts", () => {
+		expect(
+			parseDiscordAttachmentUrl("https://cdn.answeroverflow.com/222/image.png"),
+		).toBeNull();
+	});
+
+	test("returns null for non-attachment discord paths", () => {
+		expect(
+			parseDiscordAttachmentUrl(
+				"https://cdn.discordapp.com/avatars/111/abc.png",
+			),
+		).toBeNull();
+	});
+
+	test("returns null for invalid urls", () => {
+		expect(parseDiscordAttachmentUrl("not a url")).toBeNull();
+		expect(parseDiscordAttachmentUrl("")).toBeNull();
+	});
+});
+
+describe("rewriteDiscordMediaUrlToCdn", () => {
+	test("rewrites a signed discord attachment url to the cdn", () => {
+		expect(
+			rewriteDiscordMediaUrlToCdn(
+				"https://cdn.discordapp.com/attachments/111/222/image.png?ex=68b0&is=68af&hm=abc",
+				CDN_DOMAIN,
+			),
+		).toBe("https://cdn.answeroverflow.com/222/image.png");
+	});
+
+	test("leaves already-cdn urls unchanged", () => {
+		const url = "https://cdn.answeroverflow.com/222/image.png";
+		expect(rewriteDiscordMediaUrlToCdn(url, CDN_DOMAIN)).toBe(url);
+	});
+
+	test("leaves non-attachment urls unchanged", () => {
+		const url = "https://example.com/image.png";
+		expect(rewriteDiscordMediaUrlToCdn(url, CDN_DOMAIN)).toBe(url);
+	});
+
+	test("leaves invalid urls unchanged", () => {
+		expect(rewriteDiscordMediaUrlToCdn("not a url", CDN_DOMAIN)).toBe(
+			"not a url",
+		);
+	});
+});

--- a/packages/database/convex/shared/mediaUrl.ts
+++ b/packages/database/convex/shared/mediaUrl.ts
@@ -1,0 +1,58 @@
+const DISCORD_CDN_HOSTS = new Set([
+	"cdn.discordapp.com",
+	"media.discordapp.net",
+]);
+
+export function cdnUrlForAttachment(
+	id: bigint | string,
+	filename: string,
+	cdnDomain: string,
+): string {
+	return `https://${cdnDomain}/${id}/${filename}`;
+}
+
+export function parseDiscordAttachmentUrl(
+	url: string,
+): { id: string; filename: string } | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+
+	if (!DISCORD_CDN_HOSTS.has(parsed.hostname)) {
+		return null;
+	}
+
+	const segments = parsed.pathname.split("/").filter(Boolean);
+	if (segments[0] !== "attachments" || segments.length < 4) {
+		return null;
+	}
+
+	const id = segments[2];
+	const encodedFilename = segments[3];
+	if (!id || !encodedFilename) {
+		return null;
+	}
+
+	let filename: string;
+	try {
+		filename = decodeURIComponent(encodedFilename);
+	} catch {
+		filename = encodedFilename;
+	}
+
+	return { id, filename };
+}
+
+export function rewriteDiscordMediaUrlToCdn(
+	url: string,
+	cdnDomain: string,
+): string {
+	const parsed = parseDiscordAttachmentUrl(url);
+	if (!parsed) {
+		return url;
+	}
+	return cdnUrlForAttachment(parsed.id, parsed.filename, cdnDomain);
+}

--- a/packages/database/convex/shared/messages.ts
+++ b/packages/database/convex/shared/messages.ts
@@ -1,11 +1,20 @@
 import type { Infer } from "convex/values";
 import { getManyFrom, getOneFrom } from "convex-helpers/server/relationships";
 import { Array as Arr, Predicate } from "effect";
-import type { Doc } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../client";
-import type { attachmentSchema, emojiSchema, messageSchema } from "../schema";
+import type {
+	attachmentSchema,
+	emojiSchema,
+	MessageSnapshot,
+	messageSchema,
+} from "../schema";
 import { anonymizeDiscordAccount } from "./anonymization.js";
 import type { QueryCtxWithCache } from "./dataAccess";
+import {
+	cdnUrlForAttachment,
+	rewriteDiscordMediaUrlToCdn,
+} from "./mediaUrl.js";
 
 type Message = Infer<typeof messageSchema>;
 type MessageDoc = Doc<"messages">;
@@ -563,6 +572,69 @@ export async function upsertManyMessagesOptimized(
 	}
 }
 
+async function resolveSnapshotEmbedMedia<
+	T extends {
+		url?: string;
+		proxyUrl?: string;
+		s3Key?: string;
+		storageId?: Id<"_storage">;
+	},
+>(
+	ctx: QueryCtxWithCache,
+	media: T | undefined,
+	cdnDomain: string,
+): Promise<T | undefined> {
+	if (!media) {
+		return media;
+	}
+	if (media.s3Key) {
+		const url = `https://${cdnDomain}/${media.s3Key}`;
+		return { ...media, url, proxyUrl: url };
+	}
+	if (media.storageId) {
+		const url = await ctx.storage.getUrl(media.storageId);
+		if (url) {
+			return { ...media, url, proxyUrl: url };
+		}
+		return media;
+	}
+	if (media.url) {
+		const url = rewriteDiscordMediaUrlToCdn(media.url, cdnDomain);
+		if (url !== media.url) {
+			return { ...media, url, proxyUrl: url };
+		}
+	}
+	return media;
+}
+
+async function resolveSnapshotForDisplay(
+	ctx: QueryCtxWithCache,
+	snapshot: MessageSnapshot,
+	cdnDomain: string,
+): Promise<MessageSnapshot> {
+	const attachments = snapshot.attachments?.map((attachment) => ({
+		...attachment,
+		url: cdnUrlForAttachment(attachment.id, attachment.filename, cdnDomain),
+	}));
+
+	const embeds = snapshot.embeds
+		? await Promise.all(
+				snapshot.embeds.map(async (embed) => ({
+					...embed,
+					image: await resolveSnapshotEmbedMedia(ctx, embed.image, cdnDomain),
+					thumbnail: await resolveSnapshotEmbedMedia(
+						ctx,
+						embed.thumbnail,
+						cdnDomain,
+					),
+					video: await resolveSnapshotEmbedMedia(ctx, embed.video, cdnDomain),
+				})),
+			)
+		: undefined;
+
+	return { ...snapshot, attachments, embeds };
+}
+
 export type EnrichedMessageReference = {
 	messageId: bigint;
 	message: EnrichedMessage | null;
@@ -1024,9 +1096,15 @@ export async function enrichMessageForDisplay(
 		}
 	}
 
-	const messageWithResolvedEmbeds = embedsWithResolvedUrls
-		? { ...message, embeds: embedsWithResolvedUrls }
-		: message;
+	const snapshotForDisplay = message.snapshot
+		? await resolveSnapshotForDisplay(ctx, message.snapshot, cdnDomain)
+		: undefined;
+
+	const messageWithResolvedEmbeds = {
+		...message,
+		embeds: embedsWithResolvedUrls,
+		...(snapshotForDisplay !== undefined && { snapshot: snapshotForDisplay }),
+	};
 
 	const baseEnriched: EnrichedMessage = {
 		message: messageWithResolvedEmbeds,


### PR DESCRIPTION
## Summary
- Forwarded Discord messages stored snapshot attachments with raw signed `cdn.discordapp.com` URLs and never uploaded them, so images expired after ~1 day.
- Indexing and message sync now upload snapshot attachments (and Discord-hosted snapshot embed media) to S3 under the same `${id}/${filename}` key as normal attachments.
- `enrichMessageForDisplay` rewrites snapshot attachment/embed URLs to `cdn.answeroverflow.com` at read time. Already-expired forwards stay broken until the channel is reindexed (no giant backfill).

## Test plan
- [x] `bun run test -- src/utils/snapshot-media.test.ts` in `apps/discord-bot` (6 pass)
- [x] `bun run test -- convex/shared/mediaUrl.test.ts` in `packages/database` (12 pass)
- [ ] CI lint + typecheck
- [ ] After bot + Convex deploy, new/reindexed forwards should load from cdn.answeroverflow.com
- [ ] Existing expired thread https://www.answeroverflow.com/m/1516563410442256475 still needs a reindex/backfill