### PR TITLE
Skip false guild leaves on restart

### DIFF
--- a/apps/discord-bot/src/core/discord-client-mock.ts
+++ b/apps/discord-bot/src/core/discord-client-mock.ts
@@ -128,6 +128,8 @@ const createDiscordClientMockService = (options: DiscordMockOptions = {}) =>
 				max_stage_video_channel_users: null,
 				nsfw_level: 0,
 				premium_progress_bar_enabled: false,
+				// Without a channels array discord.js marks the guild unavailable
+				channels: [],
 			};
 			// @ts-expect-error - _add is private but we need it for testing
 			return client.guilds._add(guildData);

--- a/apps/discord-bot/src/sync/server.test.ts
+++ b/apps/discord-bot/src/sync/server.test.ts
@@ -113,3 +113,60 @@ it.scoped("guild-parity: runs first on guildCreate", () =>
 		expect(serverLiveData?.discordId).toBe(BigInt(guild.id));
 	}).pipe(Effect.provide(makeTestLayerWithParity())),
 );
+
+it.scoped(
+	"guild-parity: skips kickedTime on guildDelete for unavailable guilds",
+	() =>
+		Effect.gen(function* () {
+			const database = yield* Database;
+			const discordMock = yield* DiscordClientMock;
+			const discord = yield* Discord;
+
+			const guild = discordMock.utilities.createMockGuild({
+				description: "A test guild",
+			});
+			discordMock.utilities.seedGuild(guild);
+
+			discordMock.utilities.emitGuildCreate(guild);
+			yield* discord.client.waitForHandlers("guildCreate");
+
+			guild.available = false;
+			discordMock.utilities.emitGuildDelete(guild);
+			yield* discord.client.waitForHandlers("guildDelete");
+
+			const serverLiveData =
+				yield* database.private.servers.getServerByDiscordId({
+					discordId: BigInt(guild.id),
+				});
+			expect(serverLiveData).not.toBeNull();
+			expect(serverLiveData?.kickedTime).toBeFalsy();
+		}).pipe(Effect.provide(makeTestLayerWithParity())),
+);
+
+it.scoped("guild-parity: sets kickedTime on guildDelete for real leaves", () =>
+	Effect.gen(function* () {
+		const database = yield* Database;
+		const discordMock = yield* DiscordClientMock;
+		const discord = yield* Discord;
+
+		const guild = discordMock.utilities.createMockGuild({
+			description: "A test guild",
+		});
+		discordMock.utilities.seedGuild(guild);
+
+		discordMock.utilities.emitGuildCreate(guild);
+		yield* discord.client.waitForHandlers("guildCreate");
+
+		discordMock.utilities.emitGuildDelete(guild);
+		yield* discord.client.waitForHandlers("guildDelete");
+
+		// getServerByDiscordId filters out kicked servers, so a null result
+		// means kickedTime was set by the guildDelete handler.
+		const serverLiveData = yield* database.private.servers.getServerByDiscordId(
+			{
+				discordId: BigInt(guild.id),
+			},
+		);
+		expect(serverLiveData).toBeNull();
+	}).pipe(Effect.provide(makeTestLayerWithParity())),
+);

--- a/apps/discord-bot/src/sync/server.ts
+++ b/apps/discord-bot/src/sync/server.ts
@@ -370,6 +370,11 @@ export const ServerParityLayer = Layer.scopedDiscard(
 					"discord.guild_id": guild.id,
 					"discord.guild_name": guild.name,
 				});
+				// Discord.js also fires guildDelete for unavailable/partial guilds
+				// (e.g. outages or reconnects); those are not real kicks/leaves.
+				if (!guild.available || !guild.name) {
+					return;
+				}
 				yield* Metric.incrementBy(activeGuilds, -1);
 
 				const db = yield* Database;


### PR DESCRIPTION
## Summary
- Discord.js can emit `guildDelete` for unavailable/partial guilds on reconnect; those are not real leaves.
- Skip kickedTime, leave analytics, and the leave DM unless the guild is available and has a name.

## Test plan
- [x] `bun run test -- src/sync/server.test.ts` in `apps/discord-bot` (4 pass)
- [x] local lint + discord-bot typecheck
- [ ] CI lint + typecheck