### PR TITLE
Load community headers without scanning every thread

### DIFF
--- a/packages/database/convex/public/channels.test.ts
+++ b/packages/database/convex/public/channels.test.ts
@@ -638,8 +638,9 @@ describe("public/channels", () => {
 					const forum = yield* createChannel(server.discordId, { type: 15 });
 					yield* enableChannelIndexing(forum.id);
 
-					for (let i = 0; i < 20; i++) {
+					for (let i = 0; i < 3; i++) {
 						yield* createChannel(server.discordId, {
+							id: forum.id + BigInt(i + 1),
 							type: 11,
 							parentId: forum.id,
 						});

--- a/packages/database/convex/public/channels.test.ts
+++ b/packages/database/convex/public/channels.test.ts
@@ -611,5 +611,161 @@ describe("public/channels", () => {
 				expect(result).toBeNull();
 			}).pipe(Effect.provide(DatabaseTestLayer)),
 		);
+
+		it.scoped("should omit non-indexed channels from the header", () =>
+			Effect.gen(function* () {
+				const database = yield* Database;
+				const server = yield* createServer();
+				const indexed = yield* createChannel(server.discordId, { type: 0 });
+				yield* enableChannelIndexing(indexed.id);
+				yield* createChannel(server.discordId, { type: 0 });
+
+				const result =
+					yield* database.public.channels.getCommunityPageHeaderData({
+						serverDiscordId: server.discordId,
+					});
+
+				expect(result?.channels.map((c) => c.id)).toEqual([indexed.id]);
+			}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
+
+		it.scoped(
+			"should not return threads as header channels, only indexed parents",
+			() =>
+				Effect.gen(function* () {
+					const database = yield* Database;
+					const server = yield* createServer();
+					const forum = yield* createChannel(server.discordId, { type: 15 });
+					yield* enableChannelIndexing(forum.id);
+
+					for (let i = 0; i < 20; i++) {
+						yield* createChannel(server.discordId, {
+							type: 11,
+							parentId: forum.id,
+						});
+					}
+
+					const result =
+						yield* database.public.channels.getCommunityPageHeaderData({
+							serverDiscordId: server.discordId,
+						});
+
+					expect(result?.channels.map((c) => c.id)).toEqual([forum.id]);
+				}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
+
+		it.scoped(
+			"should only include categories referenced by indexed channels",
+			() =>
+				Effect.gen(function* () {
+					const database = yield* Database;
+					const server = yield* createServer();
+					const referencedCategory = yield* createChannel(server.discordId, {
+						type: 4,
+						position: 0,
+					});
+					yield* createChannel(server.discordId, {
+						type: 4,
+						position: 1,
+					});
+					const channel = yield* createChannel(server.discordId, {
+						type: 0,
+						categoryId: referencedCategory.id,
+					});
+					yield* enableChannelIndexing(channel.id);
+
+					const result =
+						yield* database.public.channels.getCommunityPageHeaderData({
+							serverDiscordId: server.discordId,
+						});
+
+					expect(result?.categories.map((c) => c.id)).toEqual([
+						referencedCategory.id,
+					]);
+				}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
+
+		it.scoped("should sort channels by displayOrder when set", () =>
+			Effect.gen(function* () {
+				const database = yield* Database;
+				const server = yield* createServer();
+				const first = yield* createChannel(server.discordId, {
+					type: 0,
+					position: 5,
+				});
+				const second = yield* createChannel(server.discordId, {
+					type: 0,
+					position: 0,
+				});
+				yield* database.private.channels.updateChannelSettings({
+					channelId: first.id,
+					settings: { indexingEnabled: true, displayOrder: 1 },
+				});
+				yield* database.private.channels.updateChannelSettings({
+					channelId: second.id,
+					settings: { indexingEnabled: true, displayOrder: 2 },
+				});
+
+				const result =
+					yield* database.public.channels.getCommunityPageHeaderData({
+						serverDiscordId: server.discordId,
+					});
+
+				expect(result?.channels.map((c) => c.id)).toEqual([
+					first.id,
+					second.id,
+				]);
+			}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
+
+		it.scoped(
+			"should sort channels by category position then channel position",
+			() =>
+				Effect.gen(function* () {
+					const database = yield* Database;
+					const server = yield* createServer();
+					const earlyCategory = yield* createChannel(server.discordId, {
+						type: 4,
+						position: 0,
+					});
+					const lateCategory = yield* createChannel(server.discordId, {
+						type: 4,
+						position: 1,
+					});
+					const lateCategoryChannel = yield* createChannel(server.discordId, {
+						type: 0,
+						categoryId: lateCategory.id,
+						position: 0,
+					});
+					const earlyCategorySecond = yield* createChannel(server.discordId, {
+						type: 0,
+						categoryId: earlyCategory.id,
+						position: 3,
+					});
+					const earlyCategoryFirst = yield* createChannel(server.discordId, {
+						type: 0,
+						categoryId: earlyCategory.id,
+						position: 1,
+					});
+					yield* enableChannelIndexing(lateCategoryChannel.id);
+					yield* enableChannelIndexing(earlyCategorySecond.id);
+					yield* enableChannelIndexing(earlyCategoryFirst.id);
+
+					const result =
+						yield* database.public.channels.getCommunityPageHeaderData({
+							serverDiscordId: server.discordId,
+						});
+
+					expect(result?.channels.map((c) => c.id)).toEqual([
+						earlyCategoryFirst.id,
+						earlyCategorySecond.id,
+						lateCategoryChannel.id,
+					]);
+					expect(result?.categories.map((c) => c.id)).toEqual([
+						earlyCategory.id,
+						lateCategory.id,
+					]);
+				}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
 	});
 });

--- a/packages/database/convex/public/channels.ts
+++ b/packages/database/convex/public/channels.ts
@@ -319,50 +319,46 @@ async function getServerHeaderData(
 
 	if (!server || server.kickedTime) return null;
 
-	const [indexedSettings, serverPreferences, allServerChannels] =
-		await Promise.all([
-			ctx.db
-				.query("channelSettings")
-				.withIndex("by_serverId_and_indexingEnabled", (q) =>
-					q.eq("serverId", server.discordId).eq("indexingEnabled", true),
-				)
-				.collect(),
-			getOneFrom(ctx.db, "serverPreferences", "by_serverId", server.discordId),
-			ctx.db
-				.query("channels")
-				.withIndex("by_serverId", (q) => q.eq("serverId", server.discordId))
-				.collect(),
-		]);
-
-	const indexedChannelIds = new Set(indexedSettings.map((s) => s.channelId));
+	const [indexedSettings, serverPreferences] = await Promise.all([
+		ctx.db
+			.query("channelSettings")
+			.withIndex("by_serverId_and_indexingEnabled", (q) =>
+				q.eq("serverId", server.discordId).eq("indexingEnabled", true),
+			)
+			.collect(),
+		getOneFrom(ctx.db, "serverPreferences", "by_serverId", server.discordId),
+	]);
 
 	const settingsMap = new Map(indexedSettings.map((s) => [s.channelId, s]));
 
-	const allChannelMap = new Map(
-		allServerChannels.map((channel) => [channel.id, channel]),
+	const loadedIndexedChannels = await asyncMap(indexedSettings, (settings) =>
+		getOneFrom(
+			ctx.db,
+			"channels",
+			"by_discordChannelId",
+			settings.channelId,
+			"id",
+		),
+	);
+	const indexedChannelDocs = Arr.filter(
+		loadedIndexedChannels,
+		Predicate.isNotNull,
 	);
 
 	const categoryIds = new Set(
-		Arr.filter(allServerChannels, (channel) =>
-			indexedChannelIds.has(channel.id),
-		)
+		indexedChannelDocs
 			.map((c) => c.categoryId)
 			.filter((id): id is bigint => id !== undefined),
 	);
 
-	const categories = [];
-	for (const categoryId of categoryIds) {
-		const category = allChannelMap.get(categoryId);
-		if (category) {
-			categories.push(category);
-		}
-	}
+	const loadedCategories = await asyncMap([...categoryIds], (categoryId) =>
+		getOneFrom(ctx.db, "channels", "by_discordChannelId", categoryId, "id"),
+	);
+	const categories = Arr.filter(loadedCategories, Predicate.isNotNull);
 
 	const categoryMap = new Map(categories.map((c) => [c.id, c]));
 
-	const indexedChannels = Arr.filter(allServerChannels, (channel) =>
-		indexedChannelIds.has(channel.id),
-	)
+	const indexedChannels = indexedChannelDocs
 		.filter(
 			(c) =>
 				c.type === CHANNEL_TYPE.GuildText ||

--- a/packages/database/convex/public/servers.test.ts
+++ b/packages/database/convex/public/servers.test.ts
@@ -133,6 +133,32 @@ describe("public/servers", () => {
 			}).pipe(Effect.provide(DatabaseTestLayer)),
 		);
 
+		it.scoped(
+			"should not return threads as channels, only indexed parents",
+			() =>
+				Effect.gen(function* () {
+					const database = yield* Database;
+					const server = yield* createServer();
+					const forum = yield* createChannel(server.discordId, { type: 15 });
+					yield* enableChannelIndexing(forum.id);
+					yield* createChannel(server.discordId, { type: 0 });
+
+					for (let i = 0; i < 20; i++) {
+						yield* createChannel(server.discordId, {
+							type: 11,
+							parentId: forum.id,
+						});
+					}
+
+					const result =
+						yield* database.public.servers.getServerByDiscordIdWithChannels({
+							discordId: server.discordId,
+						});
+
+					expect(result?.channels.map((c) => c.id)).toEqual([forum.id]);
+				}).pipe(Effect.provide(DatabaseTestLayer)),
+		);
+
 		it.scoped("should include custom domain in response", () =>
 			Effect.gen(function* () {
 				const database = yield* Database;

--- a/packages/database/convex/public/servers.test.ts
+++ b/packages/database/convex/public/servers.test.ts
@@ -141,10 +141,14 @@ describe("public/servers", () => {
 					const server = yield* createServer();
 					const forum = yield* createChannel(server.discordId, { type: 15 });
 					yield* enableChannelIndexing(forum.id);
-					yield* createChannel(server.discordId, { type: 0 });
+					yield* createChannel(server.discordId, {
+						id: forum.id + 100n,
+						type: 0,
+					});
 
-					for (let i = 0; i < 20; i++) {
+					for (let i = 0; i < 3; i++) {
 						yield* createChannel(server.discordId, {
+							id: forum.id + BigInt(i + 1),
 							type: 11,
 							parentId: forum.id,
 						});

--- a/packages/database/convex/public/servers.ts
+++ b/packages/database/convex/public/servers.ts
@@ -97,15 +97,17 @@ export const getServerByDiscordIdWithChannels = publicQuery({
 			getOneFrom(ctx.db, "serverPreferences", "by_serverId", server.discordId),
 		]);
 
-		const indexedChannelIds = new Set(indexedSettings.map((s) => s.channelId));
-		const allServerChannels = await ctx.db
-			.query("channels")
-			.withIndex("by_serverId", (q) => q.eq("serverId", server.discordId))
-			.collect();
+		const loadedChannels = await asyncMap(indexedSettings, (settings) =>
+			getOneFrom(
+				ctx.db,
+				"channels",
+				"by_discordChannelId",
+				settings.channelId,
+				"id",
+			),
+		);
 
-		const channels = Arr.filter(allServerChannels, (channel) =>
-			indexedChannelIds.has(channel.id),
-		)
+		const channels = Arr.filter(loadedChannels, Predicate.isNotNull)
 			.filter(
 				(c) =>
 					c.type === CHANNEL_TYPE.GuildText ||


### PR DESCRIPTION
## Summary
- Community page headers were collecting every `channels` row for a server (including all threads), which blew Convex read limits on large communities.
- Those public queries now keep the indexed `channelSettings` lookup and load only those parent channel docs — plus referenced category rows for the header — by id.
- Same change in `getServerByDiscordIdWithChannels`. Response shape and sort order are unchanged.

## Test plan
- [x] `cd packages/database && bun run test -- convex/public/channels.test.ts convex/public/servers.test.ts` (34 pass)
- [x] `packages/database` typecheck
- [x] biome check on changed files
- [ ] CI lint + typecheck