### PR TITLE
Serve MCP protocol on GET /mcp

### DIFF
--- a/apps/main-site/src/app/(main-site)/mcp/route.ts
+++ b/apps/main-site/src/app/(main-site)/mcp/route.ts
@@ -8,6 +8,7 @@ import {
 	searchAnswerOverflow,
 	searchServers,
 } from "@/lib/mcp/tools";
+import { prefersHtmlForMcp } from "@/lib/request-routing";
 
 const buildUrl = (path: string) => `https://www.answeroverflow.com${path}`;
 
@@ -116,5 +117,8 @@ const handler = createMcpHandler(
 export { handler as POST };
 
 export function GET(request: NextRequest) {
-	return NextResponse.redirect(new URL("/mcp/setup", request.url), 307);
+	if (prefersHtmlForMcp(request.headers.get("accept") ?? "")) {
+		return NextResponse.redirect(new URL("/mcp/setup", request.url), 307);
+	}
+	return handler(request);
 }

--- a/apps/main-site/src/lib/request-routing.test.ts
+++ b/apps/main-site/src/lib/request-routing.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildRoutingResult } from "./request-routing";
+
+// isOnMainSite resolves the main hostname from NEXT_PUBLIC_BASE_URL, which is
+// unset under vitest and would fall back to localhost.
+vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://www.answeroverflow.com");
+
+function makeInput(overrides: {
+	method?: string;
+	acceptHeader?: string;
+	pathname?: string;
+	host?: string;
+}) {
+	const host = overrides.host ?? "www.answeroverflow.com";
+	const pathname = overrides.pathname ?? "/mcp";
+	return {
+		method: overrides.method ?? "GET",
+		host,
+		pathname,
+		search: "",
+		acceptHeader: overrides.acceptHeader ?? "",
+		url: `https://${host}${pathname}`,
+		bypassSubpathRedirect: false,
+	};
+}
+
+const browserAccept =
+	"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
+
+describe("buildRoutingResult GET /mcp", () => {
+	it("rewrites browser requests to /mcp/setup", () => {
+		const result = buildRoutingResult(
+			makeInput({ acceptHeader: browserAccept }),
+		);
+		expect(result).toEqual({ type: "rewrite", pathname: "/mcp/setup" });
+	});
+
+	it("does not rewrite when Accept includes text/event-stream", () => {
+		const result = buildRoutingResult(
+			makeInput({ acceptHeader: "application/json, text/event-stream" }),
+		);
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("does not rewrite when Accept includes application/json", () => {
+		const result = buildRoutingResult(
+			makeInput({ acceptHeader: "application/json" }),
+		);
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("does not rewrite when Accept includes application/mcp", () => {
+		const result = buildRoutingResult(
+			makeInput({ acceptHeader: "application/mcp+json" }),
+		);
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("does not rewrite an SSE request that also lists text/html", () => {
+		const result = buildRoutingResult(
+			makeInput({ acceptHeader: "text/event-stream, text/html" }),
+		);
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("does not rewrite when Accept is empty", () => {
+		const result = buildRoutingResult(makeInput({ acceptHeader: "" }));
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("does not rewrite when Accept is */*", () => {
+		const result = buildRoutingResult(makeInput({ acceptHeader: "*/*" }));
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("matches Accept case-insensitively", () => {
+		const result = buildRoutingResult(
+			makeInput({ acceptHeader: "TEXT/HTML,application/xhtml+xml" }),
+		);
+		expect(result).toEqual({ type: "rewrite", pathname: "/mcp/setup" });
+	});
+
+	it("does not rewrite POST /mcp", () => {
+		const result = buildRoutingResult(
+			makeInput({ method: "POST", acceptHeader: "application/json" }),
+		);
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("does not rewrite browser POST /mcp", () => {
+		const result = buildRoutingResult(
+			makeInput({ method: "POST", acceptHeader: browserAccept }),
+		);
+		expect(result).toEqual({ type: "next" });
+	});
+
+	it("rewrites tenant protocol GET /mcp to the tenant route, not setup", () => {
+		const result = buildRoutingResult(
+			makeInput({
+				host: "questions.answeroverflow.com",
+				acceptHeader: "application/json, text/event-stream",
+			}),
+		);
+		expect(result).toEqual({
+			type: "rewrite",
+			pathname: "/questions.answeroverflow.com/mcp",
+		});
+	});
+});

--- a/apps/main-site/src/lib/request-routing.ts
+++ b/apps/main-site/src/lib/request-routing.ts
@@ -95,6 +95,20 @@ function shouldHandleRequest(pathname: string) {
 	return true;
 }
 
+// MCP protocol clients poll GET /mcp expecting streamable HTTP/SSE; only
+// browsers should be sent to the install page.
+export function prefersHtmlForMcp(acceptHeader: string): boolean {
+	const accept = acceptHeader.toLowerCase();
+	if (
+		accept.includes("text/event-stream") ||
+		accept.includes("application/json") ||
+		accept.includes("application/mcp")
+	) {
+		return false;
+	}
+	return accept.includes("text/html");
+}
+
 export function buildRoutingResult(input: RoutingInput): RoutingResult {
 	if (!shouldHandleRequest(input.pathname)) {
 		return nextResult();
@@ -120,7 +134,11 @@ export function buildRoutingResult(input: RoutingInput): RoutingResult {
 		}
 	}
 
-	if (input.method === "GET" && input.pathname === "/mcp") {
+	if (
+		input.method === "GET" &&
+		input.pathname === "/mcp" &&
+		prefersHtmlForMcp(input.acceptHeader)
+	) {
 		return rewriteResult("/mcp/setup");
 	}
 


### PR DESCRIPTION
## Summary
- GET /mcp was serving the HTML install page to protocol clients that expect streamable HTTP or SSE
- Rewrite/redirect to /mcp/setup only when Accept prefers HTML; SSE, JSON, and MCP Accepts reach the existing handler
- Browser visits still land on the install UI

## Test plan
- [x] Unit tests: browser GET /mcp rewrites to setup; SSE/JSON/MCP Accepts do not; POST /mcp unchanged
- [x] `bun run lint` and main-site typecheck
- [ ] Live: browser GET /mcp still shows install UI; agent GET /mcp is MCP, not HTML