### PR TITLE
Hide empty thread messages

### DIFF
--- a/apps/main-site/src/components/message-page.tsx
+++ b/apps/main-site/src/components/message-page.tsx
@@ -23,6 +23,7 @@ import { encodeCursor } from "@packages/ui/utils/cursor";
 import {
 	ChannelType,
 	getDiscordURLForMessage,
+	hasRenderableContent,
 	MessageType,
 } from "@packages/ui/utils/discord";
 import {
@@ -170,7 +171,8 @@ export function MessageContent(props: {
 			(m) =>
 				!HIDDEN_AUTHOR_IDS.includes(m.message.authorId) &&
 				!HIDDEN_MESSAGE_TYPES.includes(m.message.type ?? 0) &&
-				m.message.id !== firstMessage?.message.id,
+				m.message.id !== firstMessage?.message.id &&
+				hasRenderableContent(m),
 		);
 	const convex = useConvex();
 	const loadMessagesPage = useCallback(
@@ -316,7 +318,8 @@ export function RepliesSection(props: {
 			(m) =>
 				!HIDDEN_AUTHOR_IDS.includes(m.message.authorId) &&
 				!HIDDEN_MESSAGE_TYPES.includes(m.message.type ?? 0) &&
-				m.message.id !== firstMessage?.message.id,
+				m.message.id !== firstMessage?.message.id &&
+				hasRenderableContent(m),
 		);
 	const convex = useConvex();
 	const loadRepliesPage = useCallback(

--- a/apps/main-site/src/lib/message-markdown.ts
+++ b/apps/main-site/src/lib/message-markdown.ts
@@ -1,5 +1,6 @@
 import { isImageAttachment } from "@packages/ui/utils/attachments";
 import { encodeCursor } from "@packages/ui/utils/cursor";
+import { hasRenderableContent, MessageType } from "@packages/ui/utils/discord";
 import { getDate } from "@packages/ui/utils/snowflake";
 import type {
 	MessagePageHeaderData,
@@ -66,6 +67,7 @@ function formatReply(
 }
 
 const HIDDEN_AUTHOR_IDS = [958907348389339146n];
+const HIDDEN_MESSAGE_TYPES = [MessageType.ThreadStarterMessage];
 
 export function buildMessageMarkdown(data: {
 	headerData: MessagePageHeaderData;
@@ -115,14 +117,17 @@ export function buildMessageMarkdown(data: {
 		lines.push("---");
 	}
 
-	if (replies.page.length > 0) {
+	const filteredReplies = replies.page.filter(
+		(r) =>
+			!HIDDEN_AUTHOR_IDS.includes(r.message.authorId) &&
+			!HIDDEN_MESSAGE_TYPES.includes(r.message.type ?? 0) &&
+			hasRenderableContent(r),
+	);
+
+	if (filteredReplies.length > 0) {
 		lines.push("");
 		lines.push("## Replies");
 		lines.push("");
-
-		const filteredReplies = replies.page.filter(
-			(r) => !HIDDEN_AUTHOR_IDS.includes(r.message.authorId),
-		);
 
 		for (let i = 0; i < filteredReplies.length; i++) {
 			const reply = filteredReplies[i];

--- a/packages/ui/src/utils/discord.test.ts
+++ b/packages/ui/src/utils/discord.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+import { hasRenderableContent } from "./discord";
+
+describe("hasRenderableContent", () => {
+	test("returns false for empty content with no extras", () => {
+		expect(
+			hasRenderableContent({ message: { content: "" }, attachments: [] }),
+		).toBe(false);
+	});
+
+	test("returns false for whitespace-only content with no extras", () => {
+		expect(
+			hasRenderableContent({
+				message: { content: "   \n\t" },
+				attachments: [],
+			}),
+		).toBe(false);
+	});
+
+	test("returns true for text content", () => {
+		expect(
+			hasRenderableContent({ message: { content: "hello" }, attachments: [] }),
+		).toBe(true);
+	});
+
+	test("returns true for whitespace-only content with an attachment", () => {
+		expect(
+			hasRenderableContent({
+				message: { content: "  " },
+				attachments: [{ url: "https://example.com/a.png" }],
+			}),
+		).toBe(true);
+	});
+
+	test("returns true for empty content with an embed", () => {
+		expect(
+			hasRenderableContent({
+				message: { content: "", embeds: [{ title: "embed" }] },
+				attachments: [],
+			}),
+		).toBe(true);
+	});
+
+	test("returns true for empty content with a sticker", () => {
+		expect(
+			hasRenderableContent({
+				message: { content: "", stickers: [{ id: "1" }] },
+				attachments: [],
+			}),
+		).toBe(true);
+	});
+
+	test("returns true for empty content with a component", () => {
+		expect(
+			hasRenderableContent({
+				message: { content: "", components: [{ type: 1 }] },
+				attachments: [],
+			}),
+		).toBe(true);
+	});
+
+	test("returns true for empty content with a snapshot", () => {
+		expect(
+			hasRenderableContent({
+				message: { content: "", snapshot: { message: {} } },
+				attachments: [],
+			}),
+		).toBe(true);
+	});
+
+	test("returns false for empty arrays and empty content", () => {
+		expect(
+			hasRenderableContent({
+				message: {
+					content: "",
+					embeds: [],
+					stickers: [],
+					components: [],
+					snapshot: null,
+				},
+				attachments: [],
+			}),
+		).toBe(false);
+	});
+
+	test("returns false for null and undefined extras with empty content", () => {
+		expect(
+			hasRenderableContent({
+				message: {
+					content: "",
+					embeds: null,
+					stickers: undefined,
+					components: null,
+					snapshot: undefined,
+				},
+				attachments: null,
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/ui/src/utils/discord.ts
+++ b/packages/ui/src/utils/discord.ts
@@ -93,6 +93,27 @@ type MessageWithServerAndChannel = {
 	id: bigint;
 };
 
+export function hasRenderableContent(enriched: {
+	message: {
+		content?: string | null;
+		embeds?: ReadonlyArray<unknown> | null;
+		stickers?: ReadonlyArray<unknown> | null;
+		components?: ReadonlyArray<unknown> | null;
+		snapshot?: unknown;
+	};
+	attachments?: ReadonlyArray<unknown> | null;
+}): boolean {
+	const { message, attachments } = enriched;
+	return (
+		(message.content?.trim().length ?? 0) > 0 ||
+		(attachments?.length ?? 0) > 0 ||
+		(message.embeds?.length ?? 0) > 0 ||
+		(message.stickers?.length ?? 0) > 0 ||
+		(message.components?.length ?? 0) > 0 ||
+		(message.snapshot !== null && message.snapshot !== undefined)
+	);
+}
+
 export function getDiscordURLForMessage(message: MessageWithServerAndChannel) {
 	const serverId = message.serverId.toString();
 	const channelId = message.channelId.toString();


### PR DESCRIPTION
## Summary
- Hide public thread replies that have no renderable body (empty/whitespace content and no attachments, embeds, stickers, components, or snapshot).
- Apply the same hide list in the thread UI filters and markdown export.
- Leave the root "Original message was deleted" path unchanged.

## Test plan
- [ ] Open a public thread that previously showed a blank avatar/timestamp bubble and confirm it is gone
- [ ] Confirm messages with only an attachment, embed, sticker, component, or snapshot still render
- [ ] Confirm a thread whose original message was deleted still shows "Original message was deleted"
- [ ] Confirm markdown (`/m/<id>.md`) also omits empty replies